### PR TITLE
fix: persist temporary display mode to NVS instead of RTC memory

### DIFF
--- a/include/config/config_manager.h
+++ b/include/config/config_manager.h
@@ -49,11 +49,9 @@ struct RTCConfigData {
     uint32_t lastUpdate; // 4 bytes (timestamp)
 
     // Temporary button mode (ESP32-S3 only)
-    // NOTE: These are volatile to prevent compiler optimization that might prevent
-    // RTC memory writes from completing before deep sleep
-    volatile bool inTemporaryMode; // 1 byte - flag if we're in temporary mode
+    volatile bool inTemporaryMode;       // 1 byte - flag if we're in temporary mode
     volatile uint8_t temporaryDisplayMode; // 1 byte - temporary override mode (0xFF = none)
-    volatile uint32_t temporaryModeActivationTime; // 4 bytes - when temporary mode was activated (epoch time)
+    volatile uint32_t temporaryModeActivationTime; // 4 bytes - when temporary mode was activated (epoch)
 
     // Total: ~535 bytes (well under 8KB RTC limit)
 };

--- a/include/util/button_manager.h
+++ b/include/util/button_manager.h
@@ -4,7 +4,7 @@
 // Button manager for temporary display mode switching (ESP32-S3 only)
 class ButtonManager {
 public:
-    // Duration for temporary mode in active hours (2 minutes in seconds)
+    // Duration for temporary mode (2 minutes in seconds)
     static constexpr uint32_t TEMP_MODE_ACTIVE_DURATION = 120;
 
     // Debounce delay in milliseconds
@@ -24,9 +24,20 @@ public:
     // Enable EXT1 wakeup for all buttons before entering deep sleep
     static void enableButtonWakeup();
 
-    // Handle button wakeup and set temporary display mode if needed
-    // Should be called early in boot process
+    // Handle button wakeup and set temporary display mode if needed.
+    // Handles: EXT1 wakeup, synthetic mode, and awake-press (ISR-triggered restart).
+    // Uses cycle-based expiry (TEMP_MODE_CYCLES wakeup cycles).
     static void handleWakeupMode();
+
+    // Attach GPIO falling-edge interrupts so button presses are captured while
+    // the device is awake. Call once in onInit() after pins are configured.
+    static void attachRunningInterrupts();
+
+    // Check if a button was pressed while awake (via ISR).
+    // If so, activates temporary mode in RTC config and calls esp_restart().
+    // Call this anywhere in the lifecycle to respond to button presses ASAP.
+    // Returns true if restart was triggered (caller won't reach next line).
+    static bool checkAndRestartIfButtonPressed();
 
 private:
     // Get GPIO mask for all three buttons

--- a/src/activity/activity_manager.cpp
+++ b/src/activity/activity_manager.cpp
@@ -64,6 +64,10 @@ void ActivityManager::onInit() {
 #endif
     SystemInit::loadNvsConfig();
 
+    // Attach GPIO interrupts so button presses are detected while awake
+    ButtonManager::setWakupableButtons();
+    ButtonManager::attachRunningInterrupts();
+
     DEBUG_ONLY(ConfigManager::printConfiguration(false);)
 
     setNextActivityLifecycle(Lifecycle::ON_START);
@@ -77,7 +81,6 @@ void ActivityManager::onStart() {
     if (phase == PHASE_WIFI_SETUP) {
         BootFlowManager::handlePhaseWifiSetup();
     }
-    // Setup by pressing buttons changes display mode while running - To make
 
     // Start Wifi connection. If gets failed, show Wifi Error Screen
     MyWiFiManager::reconnectWiFi();
@@ -87,6 +90,9 @@ void ActivityManager::onStart() {
         setNextActivityLifecycle(Lifecycle::ON_STOP);
         return;
     }
+
+    // Check if button was pressed during WiFi connect
+    ButtonManager::checkAndRestartIfButtonPressed();
 
     // Set up Time if it needed
     DeviceModeManager::setupConnectivityAndTime();
@@ -109,13 +115,22 @@ void ActivityManager::onRunning() {
         return;
     }
 
+    // Check if button was pressed before OTA/API work
+    ButtonManager::checkAndRestartIfButtonPressed();
+
     // OTA Update Check by checking scheduled time with RTC clock time
     OTAManager::checkAndApplyUpdate();
+
+    // Check if button was pressed during OTA check
+    ButtonManager::checkAndRestartIfButtonPressed();
 
     // Fetch Data from APIs and Update Display
     if (phase == PHASE_COMPLETE) {
         BootFlowManager::handlePhaseComplete();
     }
+
+    // Check if button was pressed during API fetch / display render
+    ButtonManager::checkAndRestartIfButtonPressed();
 
     setNextActivityLifecycle(Lifecycle::ON_STOP);
 }
@@ -136,6 +151,9 @@ void ActivityManager::onStop() {
 
 void ActivityManager::onShutdown() {
     setCurrentActivityLifecycle(Lifecycle::ON_SHUTDOWN);
+
+    // Final check: if button was pressed while awake, restart to handle it
+    ButtonManager::checkAndRestartIfButtonPressed();
 
     // Turn off peripherals
     DisplayManager::hibernate();

--- a/src/util/button_manager.cpp
+++ b/src/util/button_manager.cpp
@@ -3,11 +3,20 @@
 #include "config/pins.h"
 #include "config/config_manager.h"
 #include <driver/rtc_io.h>
+#include <esp_system.h>
+#include <Preferences.h>
 
 static const char* TAG = "BUTTON";
 
 // Synthetic button mode injected by long-press detection (-1 = none)
 static int8_t syntheticButtonMode = -1;
+
+// Volatile flag set by ISR when a button is pressed while device is awake.
+// -1 = no press, 0/1/2 = display mode.
+static volatile int8_t isrButtonPressed = -1;
+
+// Timestamp when interrupts were attached — used for debounce
+static unsigned long isrAttachTime = 0;
 
 void ButtonManager::setSyntheticButtonMode(int8_t mode) {
     syntheticButtonMode = mode;
@@ -28,41 +37,21 @@ void ButtonManager::setWakupableButtons() {
                  Pins::BUTTON_WEATHER_ONLY, Pins::BUTTON_DEPARTURE_ONLY);
 
         // DIAGNOSTIC: Check if GPIOs support RTC (required for EXT1 wakeup)
-        ESP_LOGI(TAG, "Checking RTC GPIO support...");
-
-        // Check GPIO 2
         if (rtc_gpio_is_valid_gpio((gpio_num_t)Pins::BUTTON_HALF_AND_HALF)) {
-            ESP_LOGI(TAG, "✓ GPIO %d supports RTC (EXT1 wakeup)", Pins::BUTTON_HALF_AND_HALF);
+            ESP_LOGI(TAG, "✓ GPIO %d supports RTC", Pins::BUTTON_HALF_AND_HALF);
         } else {
-            ESP_LOGE(TAG, "✗ GPIO %d does NOT support RTC - cannot wake from deep sleep!",
-                     Pins::BUTTON_HALF_AND_HALF);
+            ESP_LOGE(TAG, "✗ GPIO %d does NOT support RTC!", Pins::BUTTON_HALF_AND_HALF);
         }
-
-        // Check GPIO 3
         if (rtc_gpio_is_valid_gpio((gpio_num_t)Pins::BUTTON_WEATHER_ONLY)) {
-            ESP_LOGI(TAG, "✓ GPIO %d supports RTC (EXT1 wakeup)", Pins::BUTTON_WEATHER_ONLY);
+            ESP_LOGI(TAG, "✓ GPIO %d supports RTC", Pins::BUTTON_WEATHER_ONLY);
         } else {
-            ESP_LOGE(TAG, "✗ GPIO %d does NOT support RTC - cannot wake from deep sleep!",
-                     Pins::BUTTON_WEATHER_ONLY);
+            ESP_LOGE(TAG, "✗ GPIO %d does NOT support RTC!", Pins::BUTTON_WEATHER_ONLY);
         }
-
-        // Check GPIO 5 (or 4)
         if (rtc_gpio_is_valid_gpio((gpio_num_t)Pins::BUTTON_DEPARTURE_ONLY)) {
-            ESP_LOGI(TAG, "✓ GPIO %d supports RTC (EXT1 wakeup)", Pins::BUTTON_DEPARTURE_ONLY);
+            ESP_LOGI(TAG, "✓ GPIO %d supports RTC", Pins::BUTTON_DEPARTURE_ONLY);
         } else {
-            ESP_LOGE(TAG, "✗ GPIO %d does NOT support RTC - cannot wake from deep sleep!",
-                     Pins::BUTTON_DEPARTURE_ONLY);
+            ESP_LOGE(TAG, "✗ GPIO %d does NOT support RTC!", Pins::BUTTON_DEPARTURE_ONLY);
         }
-
-        // DIAGNOSTIC: Check current button states
-        delay(20); // Allow pull-ups to stabilize
-        ESP_LOGI(TAG, "Current button states:");
-        ESP_LOGI(TAG, "  GPIO %d: %s", Pins::BUTTON_HALF_AND_HALF,
-                 digitalRead(Pins::BUTTON_HALF_AND_HALF) == HIGH ? "HIGH (not pressed)" : "LOW (PRESSED!)");
-        ESP_LOGI(TAG, "  GPIO %d: %s", Pins::BUTTON_WEATHER_ONLY,
-                 digitalRead(Pins::BUTTON_WEATHER_ONLY) == HIGH ? "HIGH (not pressed)" : "LOW (PRESSED!)");
-        ESP_LOGI(TAG, "  GPIO %d: %s", Pins::BUTTON_DEPARTURE_ONLY,
-                 digitalRead(Pins::BUTTON_DEPARTURE_ONLY) == HIGH ? "HIGH (not pressed)" : "LOW (PRESSED!)");
     } else {
         ESP_LOGI(TAG, "Button manager not available");
     }
@@ -70,32 +59,22 @@ void ButtonManager::setWakupableButtons() {
 
 int8_t ButtonManager::getWakeupButtonMode() {
     if (HAS_BUTTON) {
-        // Check if wakeup was caused by EXT1 (button press)
         if (esp_sleep_get_wakeup_cause() != ESP_SLEEP_WAKEUP_EXT1) {
             return -1;
         }
-
-        // Get which GPIO caused the wakeup
         uint64_t wakeup_pin_mask = esp_sleep_get_ext1_wakeup_status();
+        if (wakeup_pin_mask == 0) return -1;
 
-        if (wakeup_pin_mask == 0) {
-            ESP_LOGW(TAG, "EXT1 wakeup but no pin detected");
-            return -1;
-        }
-
-        // Check which button was pressed
         if (wakeup_pin_mask & (1ULL << Pins::BUTTON_HALF_AND_HALF)) {
-            ESP_LOGI(TAG, "Woken by BUTTON_HALF_AND_HALF (GPIO %d)", Pins::BUTTON_HALF_AND_HALF);
+            ESP_LOGI(TAG, "Woken by BUTTON_HALF_AND_HALF");
             return DISPLAY_MODE_HALF_AND_HALF;
         } else if (wakeup_pin_mask & (1ULL << Pins::BUTTON_WEATHER_ONLY)) {
-            ESP_LOGI(TAG, "Woken by BUTTON_WEATHER_ONLY (GPIO %d)", Pins::BUTTON_WEATHER_ONLY);
+            ESP_LOGI(TAG, "Woken by BUTTON_WEATHER_ONLY");
             return DISPLAY_MODE_WEATHER_ONLY;
         } else if (wakeup_pin_mask & (1ULL << Pins::BUTTON_DEPARTURE_ONLY)) {
-            ESP_LOGI(TAG, "Woken by BUTTON_DEPARTURE_ONLY (GPIO %d)", Pins::BUTTON_DEPARTURE_ONLY);
+            ESP_LOGI(TAG, "Woken by BUTTON_DEPARTURE_ONLY");
             return DISPLAY_MODE_TRANSPORT_ONLY;
         }
-
-        ESP_LOGW(TAG, "EXT1 wakeup from unknown button: 0x%llx", wakeup_pin_mask);
     }
     return -1;
 }
@@ -103,113 +82,157 @@ int8_t ButtonManager::getWakeupButtonMode() {
 void ButtonManager::enableButtonWakeup() {
     if (HAS_BUTTON) {
         uint64_t button_mask = getButtonMask();
-
-        ESP_LOGI(TAG, "Enabling EXT1 wakeup for buttons...");
-        ESP_LOGI(TAG, "  Button mask: 0x%llx", button_mask);
-        ESP_LOGI(TAG, "  GPIO %d bit: %d", Pins::BUTTON_HALF_AND_HALF,
-                 (button_mask & (1ULL << Pins::BUTTON_HALF_AND_HALF)) ? 1 : 0);
-        ESP_LOGI(TAG, "  GPIO %d bit: %d", Pins::BUTTON_WEATHER_ONLY,
-                 (button_mask & (1ULL << Pins::BUTTON_WEATHER_ONLY)) ? 1 : 0);
-        ESP_LOGI(TAG, "  GPIO %d bit: %d", Pins::BUTTON_DEPARTURE_ONLY,
-                 (button_mask & (1ULL << Pins::BUTTON_DEPARTURE_ONLY)) ? 1 : 0);
-
-        // Enable EXT1 wakeup on ANY_LOW (any button press will wake the device)
         esp_err_t result = esp_sleep_enable_ext1_wakeup(button_mask, ESP_EXT1_WAKEUP_ANY_LOW);
-
         if (result == ESP_OK) {
-            ESP_LOGI(TAG, "✓ EXT1 wakeup enabled successfully (mask: 0x%llx)", button_mask);
+            ESP_LOGI(TAG, "✓ EXT1 wakeup enabled (mask: 0x%llx)", button_mask);
         } else {
-            ESP_LOGE(TAG, "✗ Failed to enable EXT1 wakeup! Error: 0x%x (%s)",
-                     result, esp_err_to_name(result));
-            ESP_LOGE(TAG, "  This usually means one or more GPIOs don't support RTC!");
+            ESP_LOGE(TAG, "✗ EXT1 wakeup failed: %s", esp_err_to_name(result));
         }
     }
 }
 
 uint64_t ButtonManager::getButtonMask() {
     if (HAS_BUTTON) {
-        // Create mask for all three button GPIOs
         return (1ULL << Pins::BUTTON_HALF_AND_HALF) |
-            (1ULL << Pins::BUTTON_WEATHER_ONLY) |
-            (1ULL << Pins::BUTTON_DEPARTURE_ONLY);
+               (1ULL << Pins::BUTTON_WEATHER_ONLY) |
+               (1ULL << Pins::BUTTON_DEPARTURE_ONLY);
+    }
+    return 0;
+}
+
+// =============================================================================
+// handleWakeupMode() — seconds-based temporary mode
+// =============================================================================
+void ButtonManager::handleWakeupMode() {
+    if (!HAS_BUTTON) return;
+
+    RTCConfigData& config = ConfigManager::getConfig();
+    time_t currentTime;
+    time(&currentTime);
+
+    // Determine if a new button press occurred (from EXT1, synthetic mode, or NVS pending)
+    int8_t buttonMode = syntheticButtonMode;
+    if (buttonMode >= 0) {
+        ESP_LOGI(TAG, "Consuming synthetic button mode: %d", buttonMode);
+        syntheticButtonMode = -1;
     } else {
-        return 0;
+        buttonMode = getWakeupButtonMode();
+    }
+
+    // Check for pending temp mode saved to NVS by checkAndRestartIfButtonPressed()
+    if (buttonMode < 0) {
+        Preferences prefs;
+        if (prefs.begin("mystation", false)) {
+            if (prefs.getBool("pendingTemp", false)) {
+                buttonMode = (int8_t)prefs.getUChar("pendingTempMode", 0xFF);
+                // Clear the pending flag
+                prefs.putBool("pendingTemp", false);
+                prefs.remove("pendingTempMode");
+                ESP_LOGI(TAG, "Consumed pending temp mode from NVS: %d", buttonMode);
+                if (buttonMode == (int8_t)0xFF) buttonMode = -1;
+            }
+            prefs.end();
+        }
+    }
+
+    if (buttonMode >= 0) {
+        // New button press — activate/reset temp mode
+        ESP_LOGI(TAG, "Button press! Activating temp mode: %d", buttonMode);
+        config.inTemporaryMode = true;
+        config.temporaryDisplayMode = (uint8_t)buttonMode;
+        config.temporaryModeActivationTime = (uint32_t)currentTime;
+
+    } else if (config.inTemporaryMode) {
+        // No new button press — check if awake-press needs stamping or if expired
+
+        if (config.temporaryModeActivationTime == 0) {
+            // ISR set inTemporaryMode during awake cycle but couldn't stamp time.
+            // Stamp it now (first boot after esp_restart).
+            config.temporaryModeActivationTime = (uint32_t)currentTime;
+            ESP_LOGI(TAG, "Awake-press boot — stamped activation time");
+        }
+
+        int elapsed = (int)(currentTime - config.temporaryModeActivationTime);
+        ESP_LOGI(TAG, "Temp mode elapsed: %d/%d s", elapsed, TEMP_MODE_ACTIVE_DURATION);
+
+        if (elapsed >= (int)TEMP_MODE_ACTIVE_DURATION) {
+            config.inTemporaryMode = false;
+            config.temporaryDisplayMode = 0xFF;
+            config.temporaryModeActivationTime = 0;
+            ESP_LOGI(TAG, "Temp mode expired — reverting to configured mode");
+        }
     }
 }
 
-void ButtonManager::handleWakeupMode() {
-    if (HAS_BUTTON) {
-        RTCConfigData& config = ConfigManager::getConfig();
+// =============================================================================
+// GPIO ISR handlers — IRAM-safe, minimal work.
+// Only the FIRST press is recorded; subsequent triggers are ignored until consumed.
+// =============================================================================
+static void IRAM_ATTR isrButton1() { if (isrButtonPressed < 0) isrButtonPressed = DISPLAY_MODE_HALF_AND_HALF; }
+static void IRAM_ATTR isrButton2() { if (isrButtonPressed < 0) isrButtonPressed = DISPLAY_MODE_WEATHER_ONLY; }
+static void IRAM_ATTR isrButton3() { if (isrButtonPressed < 0) isrButtonPressed = DISPLAY_MODE_TRANSPORT_ONLY; }
 
-        time_t currentTime;
-        time(&currentTime);
+void ButtonManager::attachRunningInterrupts() {
+    if (!HAS_BUTTON) return;
 
-        // Consume synthetic mode injected by long-press detection (if any)
-        int8_t buttonMode = syntheticButtonMode;
-        if (buttonMode >= 0) {
-            ESP_LOGI(TAG, "Consuming synthetic button mode: %d", buttonMode);
-            syntheticButtonMode = -1; // consume it
-        } else {
-            buttonMode = getWakeupButtonMode();
-        }
+    isrButtonPressed = -1;
 
-        if (buttonMode >= 0) {
-            // Button press detected
-            ESP_LOGI(TAG, "Woken by button press! Temporary display mode: %d", buttonMode);
+    // De-init RTC GPIO for button pins — after deep sleep wakeup, pins may still
+    // be in RTC mode which prevents normal GPIO interrupts from working.
+    rtc_gpio_deinit((gpio_num_t)Pins::BUTTON_HALF_AND_HALF);
+    rtc_gpio_deinit((gpio_num_t)Pins::BUTTON_WEATHER_ONLY);
+    rtc_gpio_deinit((gpio_num_t)Pins::BUTTON_DEPARTURE_ONLY);
 
-            // Check if same button pressed again (reset timer) or different button (switch mode)
-            if (config.inTemporaryMode && config.temporaryDisplayMode == buttonMode) {
-                ESP_LOGI(TAG, "Same button pressed - resetting temp mode timer");
-                config.temporaryModeActivationTime = (uint32_t)currentTime;
-            } else if (config.inTemporaryMode) {
-                ESP_LOGI(TAG, "Different button pressed - switching temp mode");
-                config.temporaryDisplayMode = buttonMode;
-                config.temporaryModeActivationTime = (uint32_t)currentTime;
-            } else {
-                ESP_LOGI(TAG, "Activating temp mode for first time");
-                config.inTemporaryMode = true;
-                config.temporaryDisplayMode = buttonMode;
-                config.temporaryModeActivationTime = (uint32_t)currentTime;
-            }
-            ESP_LOGI(TAG, "Temp mode activated at time: %u", config.temporaryModeActivationTime);
-        } else {
-            // No button press (timer wake or other cause)
-            // Check if existing temp mode should be cleared due to time expiration
-            if (config.inTemporaryMode) {
-                int elapsed = (int)(currentTime - config.temporaryModeActivationTime);
-                const int TEMP_MODE_DURATION = TEMP_MODE_ACTIVE_DURATION; // 120 seconds
+    // Re-configure as normal GPIO with pull-up
+    pinMode(Pins::BUTTON_HALF_AND_HALF, INPUT_PULLUP);
+    pinMode(Pins::BUTTON_WEATHER_ONLY, INPUT_PULLUP);
+    pinMode(Pins::BUTTON_DEPARTURE_ONLY, INPUT_PULLUP);
+    delay(10); // Allow pull-ups to stabilize
 
-                ESP_LOGI(TAG, "Timer wake with active temp mode - checking expiration");
-                ESP_LOGI(TAG, "  Temp mode elapsed time: %d seconds (limit: %d seconds)",
-                         elapsed, TEMP_MODE_DURATION);
+    attachInterrupt(digitalPinToInterrupt(Pins::BUTTON_HALF_AND_HALF), isrButton1, FALLING);
+    attachInterrupt(digitalPinToInterrupt(Pins::BUTTON_WEATHER_ONLY),  isrButton2, FALLING);
+    attachInterrupt(digitalPinToInterrupt(Pins::BUTTON_DEPARTURE_ONLY), isrButton3, FALLING);
 
-                if (elapsed >= TEMP_MODE_DURATION) {
-                    // Temp mode has expired - clear it BEFORE display decision
-                    ESP_LOGI(TAG, "Temp mode expired - clearing flags");
-                    ESP_LOGI(
-                        TAG, "  Before clear: inTemporaryMode=%d, displayMode=%d, activationTime=%u",
-                        config.inTemporaryMode, config.temporaryDisplayMode,
-                        config.temporaryModeActivationTime);
+    // Record attach time for debounce — ignore ISR triggers in the first 500ms
+    isrAttachTime = millis();
 
-                    config.inTemporaryMode = false;
-                    config.temporaryDisplayMode = 0xFF;
-                    config.temporaryModeActivationTime = 0;
+    // Discard any ISR that fired during attachment (pin was already LOW)
+    isrButtonPressed = -1;
 
-                    // Force memory barriers to ensure RTC writes complete
-                    asm volatile("" ::: "memory");
-                    __sync_synchronize();
-                    esp_rom_delay_us(2000); // 2ms delay for RTC write
+    ESP_LOGI(TAG, "Running-mode interrupts attached (GPIO %d, %d, %d)",
+             Pins::BUTTON_HALF_AND_HALF, Pins::BUTTON_WEATHER_ONLY, Pins::BUTTON_DEPARTURE_ONLY);
+}
 
-                    ESP_LOGI(
-                        TAG, "  After clear: inTemporaryMode=%d, displayMode=%d, activationTime=%u",
-                        config.inTemporaryMode, config.temporaryDisplayMode,
-                        config.temporaryModeActivationTime);
-                    ESP_LOGI(TAG, "Temp mode cleared - will display configured mode");
-                } else {
-                    ESP_LOGI(TAG, "Temp mode still active - %d seconds remaining",
-                             TEMP_MODE_DURATION - elapsed);
-                }
-            }
-        }
+bool ButtonManager::checkAndRestartIfButtonPressed() {
+    if (!HAS_BUTTON) return false;
+
+    int8_t mode = isrButtonPressed;
+    if (mode < 0) return false;
+
+    // Debounce: ignore if triggered within 500ms of attaching interrupts
+    if ((millis() - isrAttachTime) < 500) {
+        isrButtonPressed = -1;
+        return false;
     }
+
+    ESP_LOGI(TAG, "Button pressed while awake (mode %d) — activating temp mode, restarting", mode);
+
+    // Persist pending temp mode to NVS so it survives esp_restart()
+    // (RTC_DATA_ATTR is lost on software reset, only preserved across deep sleep)
+    Preferences prefs;
+    if (prefs.begin("mystation", false)) {
+        prefs.putBool("pendingTemp", true);
+        prefs.putUChar("pendingTempMode", (uint8_t)mode);
+        prefs.end();
+        ESP_LOGI(TAG, "Saved pending temp mode %d to NVS", mode);
+    } else {
+        ESP_LOGE(TAG, "Failed to save pending temp mode to NVS");
+    }
+
+    detachInterrupt(digitalPinToInterrupt(Pins::BUTTON_HALF_AND_HALF));
+    detachInterrupt(digitalPinToInterrupt(Pins::BUTTON_WEATHER_ONLY));
+    detachInterrupt(digitalPinToInterrupt(Pins::BUTTON_DEPARTURE_ONLY));
+
+    esp_restart();
+    return true; // unreachable
 }

--- a/test/test_button_wakeup_mode/mock_time.h
+++ b/test/test_button_wakeup_mode/mock_time.h
@@ -1,0 +1,16 @@
+#ifndef MOCK_TIME_H
+#define MOCK_TIME_H
+#include <ctime>
+
+class MockTime {
+private:
+    static time_t mockCurrentTime;
+    static bool useMock;
+public:
+    static void setMockTime(time_t time) { mockCurrentTime = time; useMock = true; }
+    static void useRealTime() { useMock = false; }
+    static time_t now() { return useMock ? mockCurrentTime : time(nullptr); }
+};
+
+#endif
+

--- a/test/test_button_wakeup_mode/mocks/config_manager.cpp
+++ b/test/test_button_wakeup_mode/mocks/config_manager.cpp
@@ -1,0 +1,182 @@
+#ifdef NATIVE_TEST
+
+#include "config/config_manager.h"
+#include <vector>
+#include <cstring>
+
+// Mock RTC memory for native testing
+RTCConfigData ConfigManager::rtcConfig = {
+    DISPLAY_MODE_HALF_AND_HALF, // displayMode
+    0.0f, // latitude
+    0.0f, // longitude
+    "", // cityName
+    "", // ssid
+    "", // ipAddress
+    "", // selectedStopId
+    "", // selectedStopName
+    3, // weatherInterval
+    3, // transportInterval
+    "06:00", // transportActiveStart
+    "09:00", // transportActiveEnd
+    5, // walkingTime
+    "22:30", // sleepStart
+    "05:30", // sleepEnd
+    false, // weekendMode
+    "08:00", // weekendTransportStart
+    "20:00", // weekendTransportEnd
+    "23:00", // weekendSleepStart
+    "07:00", // weekendSleepEnd
+    true, // otaEnabled
+    "03:00", // otaCheckTime
+    (uint16_t)(
+        FILTER_R | FILTER_S | FILTER_U | FILTER_TRAM | FILTER_BUS | FILTER_HIGHFLOOR | FILTER_FERRY | FILTER_CALLBUS),
+    // filterFlags
+    false, // configMode
+    0, // lastUpdate
+    false, // inTemporaryMode
+    0xFF, // temporaryDisplayMode
+    0 // temporaryModeActivationTime
+};
+
+ConfigManager& ConfigManager::getInstance() {
+    static ConfigManager instance;
+    return instance;
+}
+
+bool ConfigManager::loadFromNVS(bool force) {
+    // Mock implementation
+    return true;
+}
+
+bool ConfigManager::saveToNVS() {
+    // Mock implementation
+    return true;
+}
+
+void ConfigManager::setLocation(float lat, float lon, const String& city) {
+    rtcConfig.latitude = lat;
+    rtcConfig.longitude = lon;
+    copyString(rtcConfig.cityName, city, sizeof(rtcConfig.cityName));
+}
+
+void ConfigManager::setNetwork(const String& ssid, const String& ip) {
+    copyString(rtcConfig.ssid, ssid, sizeof(rtcConfig.ssid));
+    copyString(rtcConfig.ipAddress, ip, sizeof(rtcConfig.ipAddress));
+}
+
+void ConfigManager::setStop(const String& stopId, const String& stopName) {
+    copyString(rtcConfig.selectedStopId, stopId, sizeof(rtcConfig.selectedStopId));
+    copyString(rtcConfig.selectedStopName, stopName, sizeof(rtcConfig.selectedStopName));
+}
+
+void ConfigManager::setTimingConfig(int weatherInt, int transportInt, int walkTime) {
+    rtcConfig.weatherInterval = weatherInt;
+    rtcConfig.transportInterval = transportInt;
+    rtcConfig.walkingTime = walkTime;
+}
+
+void ConfigManager::setActiveHours(const String& start, const String& end) {
+    copyString(rtcConfig.transportActiveStart, start, sizeof(rtcConfig.transportActiveStart));
+    copyString(rtcConfig.transportActiveEnd, end, sizeof(rtcConfig.transportActiveEnd));
+}
+
+void ConfigManager::setSleepHours(const String& start, const String& end) {
+    copyString(rtcConfig.sleepStart, start, sizeof(rtcConfig.sleepStart));
+    copyString(rtcConfig.sleepEnd, end, sizeof(rtcConfig.sleepEnd));
+}
+
+void ConfigManager::setWeekendMode(bool enabled) {
+    rtcConfig.weekendMode = enabled;
+}
+
+void ConfigManager::setWeekendHours(const String& transStart, const String& transEnd,
+                                    const String& sleepStart, const String& sleepEnd) {
+    copyString(rtcConfig.weekendTransportStart, transStart, sizeof(rtcConfig.weekendTransportStart));
+    copyString(rtcConfig.weekendTransportEnd, transEnd, sizeof(rtcConfig.weekendTransportEnd));
+    copyString(rtcConfig.weekendSleepStart, sleepStart, sizeof(rtcConfig.weekendSleepStart));
+    copyString(rtcConfig.weekendSleepEnd, sleepEnd, sizeof(rtcConfig.weekendSleepEnd));
+}
+
+void ConfigManager::setFilterFlag(uint16_t flag, bool enabled) {
+    if (enabled) {
+        rtcConfig.filterFlags |= flag;
+    } else {
+        rtcConfig.filterFlags &= ~flag;
+    }
+}
+
+bool ConfigManager::getFilterFlag(uint16_t flag) {
+    return (rtcConfig.filterFlags & flag) != 0;
+}
+
+std::vector<String> ConfigManager::getActiveFilters() {
+    std::vector<String> filters;
+    if (rtcConfig.filterFlags & FILTER_R) filters.push_back("R");
+    if (rtcConfig.filterFlags & FILTER_S) filters.push_back("S-Bahn");
+    if (rtcConfig.filterFlags & FILTER_U) filters.push_back("U");
+    if (rtcConfig.filterFlags & FILTER_TRAM) filters.push_back("Tram");
+    // Check if all bus types are enabled
+    uint16_t allBusFlags = FILTER_BUS | FILTER_CALLBUS | FILTER_HIGHFLOOR;
+    if ((rtcConfig.filterFlags & allBusFlags) == allBusFlags) {
+        filters.push_back("Bus");
+    }
+    if (rtcConfig.filterFlags & FILTER_FERRY) filters.push_back("Fähre");
+    return filters;
+}
+
+void ConfigManager::setActiveFilters(const std::vector<String>& filters) {
+    rtcConfig.filterFlags = 0;
+    for (const String& filter : filters) {
+        // Support both short and long filter names
+        if (filter == "R" || filter == "RE" || filter == "Regional") {
+            rtcConfig.filterFlags |= FILTER_R;
+        } else if (filter == "S" || filter == "S-Bahn") {
+            rtcConfig.filterFlags |= FILTER_S;
+        } else if (filter == "U" || filter == "U-Bahn") {
+            rtcConfig.filterFlags |= FILTER_U;
+        } else if (filter == "Tram" || filter == "Straßenbahn") {
+            rtcConfig.filterFlags |= FILTER_TRAM;
+        } else if (filter == "Bus") {
+            rtcConfig.filterFlags |= FILTER_BUS | FILTER_CALLBUS | FILTER_HIGHFLOOR;
+        } else if (filter == "Fähre" || filter == "Ferry") {
+            rtcConfig.filterFlags |= FILTER_FERRY;
+        }
+    }
+}
+
+void ConfigManager::setDefaults() {
+    rtcConfig.displayMode = DISPLAY_MODE_HALF_AND_HALF;
+    rtcConfig.weatherInterval = 3;
+    rtcConfig.transportInterval = 3;
+    rtcConfig.walkingTime = 5;
+    std::strcpy(rtcConfig.transportActiveStart, "06:00");
+    std::strcpy(rtcConfig.transportActiveEnd, "09:00");
+    std::strcpy(rtcConfig.sleepStart, "22:30");
+    std::strcpy(rtcConfig.sleepEnd, "05:30");
+    rtcConfig.weekendMode = false;
+    std::strcpy(rtcConfig.weekendTransportStart, "08:00");
+    std::strcpy(rtcConfig.weekendTransportEnd, "20:00");
+    std::strcpy(rtcConfig.weekendSleepStart, "23:00");
+    std::strcpy(rtcConfig.weekendSleepEnd, "07:00");
+    rtcConfig.filterFlags = FILTER_S | FILTER_BUS;
+}
+
+void ConfigManager::printConfiguration(bool fromNVS) {
+    // Mock implementation - just print basic info
+    printf("=== Configuration (Mock) ===\n");
+    printf("Display Mode: %d\n", rtcConfig.displayMode);
+    printf("Weather Interval: %d hours\n", rtcConfig.weatherInterval);
+    printf("Transport Interval: %d minutes\n", rtcConfig.transportInterval);
+}
+
+void ConfigManager::copyString(char* dest, const String& src, size_t maxLen) {
+    size_t len = src.length();
+    if (len >= maxLen) {
+        len = maxLen - 1;
+    }
+    std::memcpy(dest, src.c_str(), len);
+    dest[len] = '\0';
+}
+
+#endif // NATIVE_TEST
+

--- a/test/test_button_wakeup_mode/mocks/mock_time.cpp
+++ b/test/test_button_wakeup_mode/mocks/mock_time.cpp
@@ -1,0 +1,6 @@
+#include "mock_time.h"
+
+// Initialize static members
+time_t MockTime::mockCurrentTime = 0;
+bool MockTime::useMock = false;
+

--- a/test/test_button_wakeup_mode/test_button_wakeup_mode.cpp
+++ b/test/test_button_wakeup_mode/test_button_wakeup_mode.cpp
@@ -1,0 +1,130 @@
+/**
+ * test_button_wakeup_mode.cpp
+ *
+ * Tests for the seconds-based temp mode state machine in ButtonManager.
+ * Temp mode expires after TEMP_MODE_ACTIVE_DURATION (120s) wall-clock time.
+ */
+
+#include <unity.h>
+#include <ctime>
+#include <cstring>
+
+#include "esp32_mocks.h"
+#include "esp_sleep.h"
+#include "config/config_manager.h"
+#include "config/config_struct.h"
+
+constexpr uint32_t TEMP_MODE_ACTIVE_DURATION = 120;
+
+// Simulate ISR press (awake): sets inTemporaryMode, activationTime=0 (sentinel)
+void simulateISRPress(uint8_t mode) {
+    RTCConfigData& config = ConfigManager::getConfig();
+    config.inTemporaryMode = true;
+    config.temporaryDisplayMode = mode;
+    config.temporaryModeActivationTime = 0;
+}
+
+// Simulate handleWakeupMode()
+void simulateHandleWakeupMode(int8_t ext1Mode, int8_t synthetic, time_t now) {
+    RTCConfigData& config = ConfigManager::getConfig();
+
+    int8_t buttonMode = (synthetic >= 0) ? synthetic : ext1Mode;
+
+    if (buttonMode >= 0) {
+        config.inTemporaryMode = true;
+        config.temporaryDisplayMode = (uint8_t)buttonMode;
+        config.temporaryModeActivationTime = (uint32_t)now;
+    } else if (config.inTemporaryMode) {
+        if (config.temporaryModeActivationTime == 0) {
+            config.temporaryModeActivationTime = (uint32_t)now;
+        }
+        int elapsed = (int)(now - (time_t)config.temporaryModeActivationTime);
+        if (elapsed >= (int)TEMP_MODE_ACTIVE_DURATION) {
+            config.inTemporaryMode = false;
+            config.temporaryDisplayMode = 0xFF;
+            config.temporaryModeActivationTime = 0;
+        }
+    }
+}
+
+void resetConfig() {
+    RTCConfigData& config = ConfigManager::getConfig();
+    config.inTemporaryMode = false;
+    config.temporaryDisplayMode = 0xFF;
+    config.temporaryModeActivationTime = 0;
+    config.displayMode = DISPLAY_MODE_HALF_AND_HALF;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+void test_ext1_wakeup_activates_temp_mode() {
+    resetConfig();
+    simulateHandleWakeupMode(DISPLAY_MODE_WEATHER_ONLY, -1, 1000000);
+    RTCConfigData& c = ConfigManager::getConfig();
+    TEST_ASSERT_TRUE(c.inTemporaryMode);
+    TEST_ASSERT_EQUAL(DISPLAY_MODE_WEATHER_ONLY, c.temporaryDisplayMode);
+    TEST_ASSERT_EQUAL((uint32_t)1000000, c.temporaryModeActivationTime);
+}
+
+void test_awake_press_stamps_time_on_restart() {
+    resetConfig();
+    simulateISRPress(DISPLAY_MODE_TRANSPORT_ONLY);
+    simulateHandleWakeupMode(-1, -1, 1000000);
+    RTCConfigData& c = ConfigManager::getConfig();
+    TEST_ASSERT_TRUE(c.inTemporaryMode);
+    TEST_ASSERT_EQUAL(DISPLAY_MODE_TRANSPORT_ONLY, c.temporaryDisplayMode);
+    TEST_ASSERT_EQUAL((uint32_t)1000000, c.temporaryModeActivationTime);
+}
+
+void test_temp_mode_active_before_120s() {
+    resetConfig();
+    simulateHandleWakeupMode(DISPLAY_MODE_WEATHER_ONLY, -1, 1000000);
+    simulateHandleWakeupMode(-1, -1, 1000119);
+    TEST_ASSERT_TRUE(ConfigManager::getConfig().inTemporaryMode);
+}
+
+void test_temp_mode_expires_at_120s() {
+    resetConfig();
+    simulateHandleWakeupMode(DISPLAY_MODE_WEATHER_ONLY, -1, 1000000);
+    simulateHandleWakeupMode(-1, -1, 1000120);
+    TEST_ASSERT_FALSE(ConfigManager::getConfig().inTemporaryMode);
+    TEST_ASSERT_EQUAL(0xFF, ConfigManager::getConfig().temporaryDisplayMode);
+}
+
+void test_new_press_resets_timer() {
+    resetConfig();
+    simulateHandleWakeupMode(DISPLAY_MODE_WEATHER_ONLY, -1, 1000000);
+    simulateHandleWakeupMode(DISPLAY_MODE_TRANSPORT_ONLY, -1, 1000100);
+    RTCConfigData& c = ConfigManager::getConfig();
+    TEST_ASSERT_TRUE(c.inTemporaryMode);
+    TEST_ASSERT_EQUAL(DISPLAY_MODE_TRANSPORT_ONLY, c.temporaryDisplayMode);
+    TEST_ASSERT_EQUAL((uint32_t)1000100, c.temporaryModeActivationTime);
+    simulateHandleWakeupMode(-1, -1, 1000219);
+    TEST_ASSERT_TRUE(ConfigManager::getConfig().inTemporaryMode);
+    simulateHandleWakeupMode(-1, -1, 1000220);
+    TEST_ASSERT_FALSE(ConfigManager::getConfig().inTemporaryMode);
+}
+
+void test_awake_press_expires_after_120s() {
+    resetConfig();
+    simulateISRPress(DISPLAY_MODE_WEATHER_ONLY);
+    time_t restartTime = 1000000;
+    simulateHandleWakeupMode(-1, -1, restartTime);
+    simulateHandleWakeupMode(-1, -1, restartTime + 120);
+    TEST_ASSERT_FALSE(ConfigManager::getConfig().inTemporaryMode);
+}
+
+// ── Main ────────────────────────────────────────────────────────────────
+void setUp()    { resetConfig(); }
+void tearDown() {}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_ext1_wakeup_activates_temp_mode);
+    RUN_TEST(test_awake_press_stamps_time_on_restart);
+    RUN_TEST(test_temp_mode_active_before_120s);
+    RUN_TEST(test_temp_mode_expires_at_120s);
+    RUN_TEST(test_new_press_resets_timer);
+    RUN_TEST(test_awake_press_expires_after_120s);
+    return UNITY_END();
+}


### PR DESCRIPTION
RTC_DATA_ATTR is cleared on esp_restart() (software reset) on ESP32-S3, only surviving deep sleep. This caused ISR-triggered button presses to be lost after restart (inTemporaryMode=0, temporaryDisplayMode=255). Save pending temporary mode to NVS flash in checkAndRestartIfButtonPressed() and read it back in handleWakeupMode() after restart.