### PR TITLE
Improve WiFiManager UI texts and setup screens

### DIFF
--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -890,7 +890,7 @@
         if (!r.ok) throw new Error('Netzwerkfehler');
         return r.json();
       }).then(function(resp) {
-        alert('Konfiguration gespeichert!');
+        alert('Konfiguration gespeichert!\n\nMyStation startet jetzt neu. Sie können diese Seite schließen.');
         window.close();
       }).catch(function(e) {
         alert('Fehler beim Speichern: ' + e.message);

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -85,11 +85,13 @@ Device will:
 
 ### Automatic Location Detection
 
-The device will automatically:
+When the configuration page loads, it will automatically:
 
 1. **Detect location** using Google Geolocation API
 2. **Find nearby stops** using RMV transport API
 3. **Display found stops** in configuration interface
+
+This happens via an AJAX request (`/api/init`) after the page loads — a loading indicator is shown while data is fetched.
 
 ### Access Configuration Interface
 

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -50,13 +50,12 @@ appear on the display.
 1. Select your **home WiFi network** from the list
     - ⚠️ Make sure it's a **2.4 GHz** network
 2. Enter your **WiFi password**
-3. Click **"Connect"**
+3. Click **"Speichern"** (Save)
 
 MyStation will:
 
 - Connect to your home WiFi
-- Detect your approximate location automatically
-- Discover nearby public transport stops
+- Restart automatically and proceed to application setup
 
 > 💡 After connecting to your home WiFi, the configuration page will reload automatically at the device's new IP address.
 
@@ -64,7 +63,8 @@ MyStation will:
 
 ## Step 5: Configure the Application (2 minutes)
 
-The configuration page now shows all settings. Your location and nearby stops are already detected.
+The configuration page loads quickly. Your location and nearby stops will be detected automatically
+after a few seconds (a loading indicator is shown while this happens).
 
 ### Display Mode
 

--- a/include/i18n/wm_strings_de.h
+++ b/include/i18n/wm_strings_de.h
@@ -38,7 +38,7 @@ const char HTTP_SCRIPT[] PROGMEM = "<script>function c(l){"
 const char HTTP_HEAD_END[] PROGMEM = "</head><body class='{c}'><div class='wrap'>"; // {c} = _bodyclass
 // example of embedded logo, base64 encoded inline, No styling here
 // const char HTTP_ROOT_MAIN[]        PROGMEM = "<img title=' alt=' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAADQElEQVRoQ+2YjW0VQQyE7Q6gAkgFkAogFUAqgFQAVACpAKiAUAFQAaECQgWECggVGH1PPrRvn3dv9/YkFOksoUhhfzwz9ngvKrc89JbnLxuA/63gpsCmwCADWwkNEji8fVNgotDM7osI/x777x5l9F6JyB8R4eeVql4P0y8yNsjM7KGIPBORp558T04A+CwiH1UVUItiUQmZ2XMReSEiAFgjAPBeVS96D+sCYGaUx4cFbLfmhSpnqnrZuqEJgJnd8cQplVLciAgX//Cf0ToIeOB9wpmloLQAwpnVmAXgdf6pwjpJIz+XNoeZQQZlODV9vhc1Tuf6owrAk/8qIhFbJH7eI3eEzsvydQEICqBEkZwiALfF70HyHPpqScPV5HFjeFu476SkRA0AzOfy4hYwstj2ZkDgaphE7m6XqnoS7Q0BOPs/sw0kDROzjdXcCMFCNwzIy0EcRcOvBACfh4k0wgOmBX4xjfmk4DKTS31hgNWIKBCI8gdzogTgjYjQWFMw+o9LzJoZ63GUmjWm2wGDc7EvDDOj/1IVMIyD9SUAL0WEhpriRlXv5je5S+U1i2N88zdPuoVkeB+ls4SyxCoP3kVm9jsjpEsBLoOBNC5U9SwpGdakFkviuFP1keblATkTENTYcxkzgxTKOI3jyDxqLkQT87pMA++H3XvJBYtsNbBN6vuXq5S737WqHkW1VgMQNXJ0RshMqbbT33sJ5kpHWymzcJjNTeJIymJZtSQd9NHQHS1vodoFoTMkfbJzpRnLzB2vi6BZAJxWaCr+62BC+jzAxVJb3dmmiLzLwZhZNPE5e880Suo2AZgB8e8idxherqUPnT3brBDTlPxO3Z66rVwIwySXugdNd+5ejhqp/+NmgIwGX3Py3QBmlEi54KlwmjkOytQ+iJrLJj23S4GkOeecg8G091no737qvRRdzE+HLALQoMTBbJgBsCj5RSWUlUVJiZ4SOljb05eLFWgoJ5oY6yTyJp62D39jDANoKKcSocPJD5dQYzlFAFZJflUArgTPZKZwLXAnHmerfJquUkKZEgyzqOb5TuDt1P3nwxobqwPocZA11m4A1mBx5IxNgRH21ti7KbAGiyNn3HoF/gJ0w05A8xclpwAAAABJRU5ErkJggg==' /><h1>{v}</h1><h3>WiFiManager</h3>";
-const char HTTP_ROOT_MAIN[] PROGMEM = "<h1>{t}</h1><h3>{v}</h3>";
+const char HTTP_ROOT_MAIN[] PROGMEM = "<h1>{t}</h1><h3>WLAN-Einrichtung</h3><p style='color:#555;font-size:0.9em;'>Wählen Sie Ihr Heim-WLAN (2,4 GHz) und geben Sie das Passwort ein.</p>";
 
 const char *const HTTP_PORTAL_MENU[] PROGMEM = {
 	           "<form action='/wifi'    method='get'><button>WiFi einrichten</button></form><br/>\n", // MENU_WIFI
@@ -65,7 +65,7 @@ const char HTTP_ITEM[] PROGMEM = "<div><a href='#p' onclick='c(this)' data-ssid=
 
 const char HTTP_FORM_START[] PROGMEM = "<form method='POST' action='{v}'>";
 const char HTTP_FORM_WIFI[] PROGMEM =
-	           "<label for='s'>SSID</label><input id='s' name='s' maxlength='32' autocorrect='off' autocapitalize='none' placeholder='{v}'><br/><label for='p'>Passwort</label><input id='p' name='p' maxlength='64' type='password' placeholder='{p}'><input type='checkbox' id='showpass' onclick='f()'> <label for='showpass'>Zeige Passwort</label><br/>";
+	           "<label for='s'>WLAN-Name (SSID)</label><input id='s' name='s' maxlength='32' autocorrect='off' autocapitalize='none' placeholder='{v}'><br/><label for='p'>WLAN-Passwort</label><input id='p' name='p' maxlength='64' type='password' placeholder='{p}'><input type='checkbox' id='showpass' onclick='f()'> <label for='showpass'>Passwort anzeigen</label><br/>";
 const char HTTP_FORM_WIFI_END[] PROGMEM = "";
 const char HTTP_FORM_STATIC_HEAD[] PROGMEM = "<hr><br/>";
 const char HTTP_FORM_END[] PROGMEM = "<br/><br/><button type='submit'>Speichern</button></form>";
@@ -77,7 +77,7 @@ const char HTTP_FORM_PARAM[] PROGMEM = "<br/><input id='{i}' name='{n}' maxlengt
 const char HTTP_SCAN_LINK[] PROGMEM =
 	           "<br/><form action='/wifi?refresh=1' method='POST'><button name='refresh' value='1'>Neu laden</button></form>";
 const char HTTP_SAVED[] PROGMEM =
-	           "<div class='msg'>Zugangsdaten speichern<br/>Versuche ESP mit dem Netzwerk zu verbinden.<br />Wenn dies fehlschlägt, stellen Sie die Verbindung zum AP wieder her, um es erneut zu versuchen.</div>";
+	           "<div class='msg S'><strong>WLAN-Daten gespeichert!</strong><br/><br/>MyStation verbindet sich jetzt mit Ihrem WLAN.<br/>Bitte warten – das Gerät startet automatisch neu und beginnt mit der Einrichtung.<br/><br/><small>Sie können diese Seite jetzt schließen.</small></div>";
 const char HTTP_PARAMSAVED[] PROGMEM = "<div class='msg S'>Gespeichert<br/></div>";
 const char HTTP_END[] PROGMEM = "</div></body></html>";
 const char HTTP_ERASEBTN[] PROGMEM =
@@ -86,13 +86,13 @@ const char HTTP_UPDATEBTN[] PROGMEM = "<br/><form action='/update' method='get'>
 const char HTTP_BACKBTN[] PROGMEM = "<hr><br/><form action='/' method='get'><button>Zurück</button></form>";
 
 const char HTTP_STATUS_ON[] PROGMEM =
-	           "<div class='msg S'><strong>Verbunden</strong> mit {v}<br/><em><small> mit IP {i}</small></em></div>";
+	           "<div class='msg S'><strong>✓ Verbunden</strong> mit {v}<br/><em><small>IP-Adresse: {i}</small></em></div>";
 const char HTTP_STATUS_OFF[] PROGMEM = "<div class='msg {c}'><strong>Nicht verbunden</strong> mit {v}{r}</div>";
 // {c=class} {v=ssid} {r=status_off}
-const char HTTP_STATUS_OFFPW[] PROGMEM = "<br/>Authentifizierungsfehler"; // STATION_WRONG_PASSWORD,  no eps32
-const char HTTP_STATUS_OFFNOAP[] PROGMEM = "<br/>AP nicht gefunden"; // WL_NO_SSID_AVAIL
-const char HTTP_STATUS_OFFFAIL[] PROGMEM = "<br/>Verbindung konnte nicht hergestellt werden"; // WL_CONNECT_FAILED
-const char HTTP_STATUS_NONE[] PROGMEM = "<div class='msg'>Kein AP gesetzt</div>";
+const char HTTP_STATUS_OFFPW[] PROGMEM = "<br/>Falsches Passwort"; // STATION_WRONG_PASSWORD,  no eps32
+const char HTTP_STATUS_OFFNOAP[] PROGMEM = "<br/>WLAN-Netzwerk nicht gefunden"; // WL_NO_SSID_AVAIL
+const char HTTP_STATUS_OFFFAIL[] PROGMEM = "<br/>Verbindung fehlgeschlagen – bitte erneut versuchen"; // WL_CONNECT_FAILED
+const char HTTP_STATUS_NONE[] PROGMEM = "<div class='msg'>Noch kein WLAN eingerichtet</div>";
 const char HTTP_BR[] PROGMEM = "<br/>";
 
 const char HTTP_STYLE[] PROGMEM = "<style>"
@@ -243,9 +243,9 @@ const char S_GET[] PROGMEM = "GET";
 const char S_POST[] PROGMEM = "POST";
 const char S_NA[] PROGMEM = "Unbekannt";
 const char S_passph[] PROGMEM = "********";
-const char S_titlewifisaved[] PROGMEM = "Zugangsdaten gespeichert";
+const char S_titlewifisaved[] PROGMEM = "WLAN verbunden";
 const char S_titlewifisettings[] PROGMEM = "Einstellungen gespeichert";
-const char S_titlewifi[] PROGMEM = "ESP Konfiguration";
+const char S_titlewifi[] PROGMEM = "MyStation WLAN-Einrichtung";
 const char S_titleinfo[] PROGMEM = "Info";
 const char S_titleparam[] PROGMEM = "Setup";
 const char S_titleparamsaved[] PROGMEM = "Setup gespeichert";
@@ -254,7 +254,7 @@ const char S_titlereset[] PROGMEM = "Zurücksetzen";
 const char S_titleerase[] PROGMEM = "Löschen";
 const char S_titleclose[] PROGMEM = "Schließen";
 const char S_options[] PROGMEM = "Optionen";
-const char S_nonetworks[] PROGMEM = "Keine Netzwerke gefunden. Aktualisieren, um erneut zu suchen.";
+const char S_nonetworks[] PROGMEM = "Keine WLAN-Netzwerke gefunden. Bitte \"Neu laden\" drücken.";
 const char S_staticip[] PROGMEM = "Static IP";
 const char S_staticgw[] PROGMEM = "Static gateway";
 const char S_staticdns[] PROGMEM = "Static DNS";

--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -217,11 +217,9 @@ void DisplayManager::displayPhase1WifiSetup() {
         u8g2.print("5. Warten – MyStation verbindet sich und startet automatisch neu");
         y += lineHeight;
 
-        y += 20; // Extra spacing
-        u8g2.setFont(u8g2_font_helvR08_tf); // Smaller font for note
-        u8g2.setCursor(margin, y);
+        u8g2.setFont(u8g2_font_helvB10_tf);
+        u8g2.setCursor(margin, 460);
         u8g2.print("Hinweis: Nur 2,4-GHz-WLAN wird unterstützt. 5-GHz-Netzwerke werden nicht angezeigt.");
-        y += lineHeight;
 
         // === QR CODES ON RIGHT SIDE ===
         const int16_t qrX = 540; // X position for QR codes (right side)
@@ -307,14 +305,10 @@ void DisplayManager::displayPhase2AppSetup() {
         u8g2.print("4. \"Speichern\" drücken – MyStation startet automatisch neu");
         y += lineHeight;
 
-        y += 20;
-        u8g2.setFont(u8g2_font_helvR08_tf); // Smaller font for hints
-        u8g2.setCursor(margin, y);
-        u8g2.print("Hinweis: Die Konfigurationsseite braucht einige Sekunden");
-        y += 14;
-        u8g2.setCursor(margin, y);
-        u8g2.print("zum Laden (Standort und Haltestellen werden ermittelt).");
-        y += lineHeight;
+        u8g2.setFont(u8g2_font_helvB10_tf);
+        u8g2.setCursor(margin, 462);
+        u8g2.print(
+            "Hinweis: Die Konfigurationsseite braucht einige Sekunden zum Laden (Standort und Haltestellen werden ermittelt).");
 
         // === QR CODE ON RIGHT SIDE ===
         const int16_t qrX = 540; // X position for QR code (right side)

--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -171,14 +171,19 @@ void DisplayManager::displayPhase1WifiSetup() {
         // Draw underline for title
         display.drawFastHLine(margin, y + 5, screenWidth - (2 * margin), GxEPD_BLACK);
 
-        y += lineHeight + 10; // Extra space after title
+        y += lineHeight + 5;
 
         // Draw instruction lines in German
-        u8g2.setFont(u8g2_font_helvB10_tf); // Regular 10pt for content
+        u8g2.setFont(u8g2_font_helvB10_tf);
 
-        y += 10; // Extra spacing
+        y += 10;
         u8g2.setCursor(margin, y);
-        u8g2.print("1. Mit dem MyStation-WLAN verbinden:");
+        u8g2.print("1. Gerät einschalten (Schalter auf ON schieben)");
+        y += lineHeight;
+
+        y += 10;
+        u8g2.setCursor(margin, y);
+        u8g2.print("2. Mit dem MyStation-WLAN verbinden:");
         y += lineHeight;
 
         u8g2.setCursor(margin + 20, y);
@@ -189,9 +194,9 @@ void DisplayManager::displayPhase1WifiSetup() {
         u8g2.print("• ODER manuell: WLAN \"" + apSSID + "\" wählen (kein Passwort)");
         y += lineHeight;
 
-        y += 10; // Extra spacing
+        y += 10;
         u8g2.setCursor(margin, y);
-        u8g2.print("2. Einrichtungsseite öffnen:");
+        u8g2.print("3. Einrichtungsseite öffnen:");
         y += lineHeight;
 
         u8g2.setCursor(margin + 20, y);
@@ -202,14 +207,14 @@ void DisplayManager::displayPhase1WifiSetup() {
         u8g2.print("• Falls nicht: QR-Code 2 scannen oder http://10.0.1.1 im Browser öffnen");
         y += lineHeight;
 
-        y += 10; // Extra spacing
+        y += 10;
         u8g2.setCursor(margin, y);
-        u8g2.print("3. Ihr Heim-WLAN auswählen und Passwort eingeben");
+        u8g2.print("4. Ihr Heim-WLAN auswählen und Passwort eingeben");
         y += lineHeight;
 
-        y += 10; // Extra spacing
+        y += 10;
         u8g2.setCursor(margin, y);
-        u8g2.print("4. Warten – MyStation verbindet sich und startet automatisch neu");
+        u8g2.print("5. Warten – MyStation verbindet sich und startet automatisch neu");
         y += lineHeight;
 
         y += 20; // Extra spacing

--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -273,43 +273,47 @@ void DisplayManager::displayPhase2AppSetup() {
 
         // Draw title
         u8g2.setCursor(margin, y);
-        u8g2.print("EINRICHTUNG 2/2 : MyStation Anwendungskonfiguration");
+        u8g2.print("EINRICHTUNG 2/2 : MyStation konfigurieren");
 
         // Draw underline for title
         display.drawFastHLine(margin, y + 5, screenWidth - (2 * margin), GxEPD_BLACK);
 
-        y += lineHeight + 10; // Extra space after title
+        y += lineHeight + 5;
 
         // Draw instruction lines in German
-        u8g2.setFont(u8g2_font_helvB10_tf); // Regular 10pt for content
+        u8g2.setFont(u8g2_font_helvB10_tf);
 
-        y += 10; // Extra spacing
+        y += 10;
         u8g2.setCursor(margin, y);
-        u8g2.print("1. Verbinden Sie sich mit Ihrem WLAN");
+        u8g2.print("1. Smartphone/PC mit Ihrem Heim-WLAN verbinden");
         y += lineHeight;
 
         u8g2.setCursor(margin + 20, y);
-        u8g2.print("(nicht mit dem " + apSSID + " WLAN)");
+        u8g2.print("(nicht mit \"" + apSSID + "\")");
         y += lineHeight;
 
-        y += 10; // Extra spacing
+        y += 10;
         u8g2.setCursor(margin, y);
-        u8g2.print("2. QR-Code scannen oder angezeigte URL im Browser eingeben");
+        u8g2.print("2. QR-Code scannen oder URL im Browser öffnen");
         y += lineHeight;
 
-        y += 10; // Extra spacing
+        y += 10;
         u8g2.setCursor(margin, y);
-        u8g2.print("3. Konfigurieren Sie MyStation im Webbrowser");
+        u8g2.print("3. Haltestelle, Anzeigemodus und Intervalle einstellen");
         y += lineHeight;
 
-        y += 10; // Extra spacing
+        y += 10;
         u8g2.setCursor(margin, y);
-        u8g2.print("4. Speichern Sie die Konfiguration und warten Sie etwa 10 Sekunden.");
+        u8g2.print("4. \"Speichern\" drücken – MyStation startet automatisch neu");
         y += lineHeight;
 
-        y += 10; // Extra spacing
+        y += 20;
+        u8g2.setFont(u8g2_font_helvR08_tf); // Smaller font for hints
         u8g2.setCursor(margin, y);
-        u8g2.print("MyStation startet automatisch neu");
+        u8g2.print("Hinweis: Die Konfigurationsseite braucht einige Sekunden");
+        y += 14;
+        u8g2.setCursor(margin, y);
+        u8g2.print("zum Laden (Standort und Haltestellen werden ermittelt).");
         y += lineHeight;
 
         // === QR CODE ON RIGHT SIDE ===

--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -178,49 +178,44 @@ void DisplayManager::displayPhase1WifiSetup() {
 
         y += 10; // Extra spacing
         u8g2.setCursor(margin, y);
-        u8g2.print("1. Schalten Sie MyStation an");
+        u8g2.print("1. Mit dem MyStation-WLAN verbinden:");
+        y += lineHeight;
+
+        u8g2.setCursor(margin + 20, y);
+        u8g2.print("• QR-Code 1 scannen (verbindet automatisch)");
+        y += lineHeight;
+
+        u8g2.setCursor(margin + 20, y);
+        u8g2.print("• ODER manuell: WLAN \"" + apSSID + "\" wählen (kein Passwort)");
         y += lineHeight;
 
         y += 10; // Extra spacing
         u8g2.setCursor(margin, y);
-        u8g2.print(
-            "2. Mit Smartphone/PC mit dem MyStation-Netzwerk verbinden");
+        u8g2.print("2. Einrichtungsseite öffnen:");
         y += lineHeight;
 
         u8g2.setCursor(margin + 20, y);
-        u8g2.print("1. QR-Code scannen");
+        u8g2.print("• Seite öffnet sich automatisch");
+        y += lineHeight;
+
+        u8g2.setCursor(margin + 20, y);
+        u8g2.print("• Falls nicht: QR-Code 2 scannen oder http://10.0.1.1 im Browser öffnen");
         y += lineHeight;
 
         y += 10; // Extra spacing
         u8g2.setCursor(margin, y);
-        u8g2.print("3. Seite erscheint nicht automatisch?");
-        y += lineHeight;
-
-        u8g2.setCursor(margin + 20, y);
-        u8g2.print("ggf. 2. QR-Code scannen");
+        u8g2.print("3. Ihr Heim-WLAN auswählen und Passwort eingeben");
         y += lineHeight;
 
         y += 10; // Extra spacing
         u8g2.setCursor(margin, y);
-        u8g2.print("4. Wählen Sie Ihr WLAN aus");
-        y += lineHeight;
-
-        u8g2.setCursor(margin + 20, y);
-        u8g2.print("und geben Sie Ihre WLAN-Zugangsdaten ein");
-        y += lineHeight;
-
-        y += 10; // Extra spacing
-        u8g2.setCursor(margin, y);
-        u8g2.print("5. Warten Sie etwa 10 Sekunden");
-        y += lineHeight;
-
-        u8g2.setCursor(margin + 20, y);
-        u8g2.print("System prüft Internetverbindung und leitet nächsten Schritt ein");
+        u8g2.print("4. Warten – MyStation verbindet sich und startet automatisch neu");
         y += lineHeight;
 
         y += 20; // Extra spacing
+        u8g2.setFont(u8g2_font_helvR08_tf); // Smaller font for note
         u8g2.setCursor(margin, y);
-        u8g2.print("MyStation braucht die Internetverbindung für Zeit, Wetter- und Verkehrsdaten");
+        u8g2.print("Hinweis: Nur 2,4-GHz-WLAN wird unterstützt. 5-GHz-Netzwerke werden nicht angezeigt.");
         y += lineHeight;
 
         // === QR CODES ON RIGHT SIDE ===
@@ -232,12 +227,12 @@ void DisplayManager::displayPhase1WifiSetup() {
         // QR Code 1: WiFi Connection
         int16_t qr1Y = 80;
         QRCodeHelper::drawQRCode(qrX, qr1Y, wifiQR, qrScale, qrVersion);
-        QRCodeHelper::drawQRLabel(qrX, qr1Y, qrSize, "1. " + apSSID, 15);
+        QRCodeHelper::drawQRLabel(qrX, qr1Y, qrSize, "1. WLAN verbinden", 15);
 
         // QR Code 2: Portal URL
         int16_t qr2Y = qr1Y + qrSize + 60; // Space between QR codes
         QRCodeHelper::drawQRCode(qrX, qr2Y, urlQR, qrScale, qrVersion);
-        QRCodeHelper::drawQRLabel(qrX, qr2Y, qrSize, "2. " + urlQR, 15);
+        QRCodeHelper::drawQRLabel(qrX, qr2Y, qrSize, "2. Seite öffnen", 15);
     } while (display.nextPage());
 
     ESP_LOGI(TAG, "Phase 1 WiFi setup instructions displayed with QR codes");


### PR DESCRIPTION
## Summary

Improves the user-facing text on the WiFiManager captive portal and e-paper setup screens to be clearer and more friendly.

## Changes

- Improve WiFiManager German strings for MyStation branding
- Inform user to close page after saving config
- Improve Phase 1 WiFi setup instructions on e-paper
- Add 'turn on device' as step 1 on Phase 1 setup screen
- Improve Phase 2 setup screen with clearer steps and loading hint
- Update quick-start docs to reflect lazy-loading and German UI