### PR TITLE
feat: show OTA update status on Button 3 long press

### DIFF
--- a/include/display/display_manager.h
+++ b/include/display/display_manager.h
@@ -38,6 +38,10 @@ public:
     static void displayErrorIfWifiConnectionError();
     static void displayErrorIfBatteryLow();
 
+    // === OTA Update Status ===
+    static void displayOTAProgress(const char* currentVersion, const char* targetVersion);
+    static void displayOTAUpToDate(const char* currentVersion);
+
     // Utility functions
     static void hibernate();
 

--- a/include/ota/ota_manager.h
+++ b/include/ota/ota_manager.h
@@ -23,8 +23,10 @@ namespace OTAManager {
      * - Runs OTA update task
      * - Updates last OTA check timestamp
      * - Device will restart if update is found and installed
+     *
+     * @return true if caller should skip normal rendering (up-to-date screen shown)
      */
-    void checkAndApplyUpdate();
+    bool checkAndApplyUpdate();
 
     /**
      * Mark that the user has explicitly requested an OTA update via button.

--- a/include/ota/ota_update.h
+++ b/include/ota/ota_update.h
@@ -12,10 +12,17 @@ extern char rcv_buffer[200];
 extern const char server_cert_pem_start[] asm("_binary_cert_github_bundle_pem_start");
 extern const char server_cert_pem_end[] asm("_binary_cert_github_bundle_pem_end");
 
+// OTA result codes
+enum OTAResult {
+    OTA_UP_TO_DATE,
+    OTA_UPDATE_FAILED
+    // Note: successful update reboots the device, so no "success" value needed
+};
+
 // Function declarations
 esp_err_t _http_event_handler(esp_http_client_event_t* evt);
 
-void check_ota_update();
+OTAResult check_ota_update();
 
 // Release information structure
 struct ReleaseInfo {

--- a/src/activity/activity_manager.cpp
+++ b/src/activity/activity_manager.cpp
@@ -121,7 +121,11 @@ void ActivityManager::onRunning() {
     ButtonManager::checkAndRestartIfButtonPressed();
 
     // OTA Update Check by checking scheduled time with RTC clock time
-    OTAManager::checkAndApplyUpdate();
+    if (OTAManager::checkAndApplyUpdate()) {
+        // "Up to date" screen is shown — skip normal rendering, sleep 2 min
+        setNextActivityLifecycle(Lifecycle::ON_STOP);
+        return;
+    }
 
     // Check if button was pressed during OTA check
     ButtonManager::checkAndRestartIfButtonPressed();

--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -684,3 +684,58 @@ void DisplayManager::displayErrorIfBatteryLow() {
 
     ESP_LOGI(TAG, "Battery low error displayed");
 }
+
+// ===== OTA UPDATE STATUS =====
+
+void DisplayManager::displayOTAProgress(const char* currentVersion, const char* targetVersion) {
+    ESP_LOGI(TAG, "Displaying OTA progress: %s -> %s", currentVersion, targetVersion);
+
+    display.setFullWindow();
+    display.firstPage();
+    do {
+        display.fillScreen(GxEPD_WHITE);
+        u8g2.setForegroundColor(GxEPD_BLACK);
+        u8g2.setBackgroundColor(GxEPD_WHITE);
+
+        const int16_t margin = 20;
+        int16_t y = 200;
+
+        u8g2.setFont(u8g2_font_helvB18_tf);
+        u8g2.setCursor(margin, y);
+        u8g2.print("Firmware-Update");
+
+        y += 40;
+        u8g2.setFont(u8g2_font_helvB10_tf);
+        u8g2.setCursor(margin, y);
+        u8g2.printf("%s  →  %s", currentVersion, targetVersion);
+
+        y += 40;
+        u8g2.setFont(u8g2_font_helvB10_tf);
+        u8g2.setCursor(margin, y);
+        u8g2.print("Bitte nicht ausschalten!");
+    } while (display.nextPage());
+}
+
+void DisplayManager::displayOTAUpToDate(const char* currentVersion) {
+    ESP_LOGI(TAG, "Displaying OTA up-to-date: %s", currentVersion);
+
+    display.setFullWindow();
+    display.firstPage();
+    do {
+        display.fillScreen(GxEPD_WHITE);
+        u8g2.setForegroundColor(GxEPD_BLACK);
+        u8g2.setBackgroundColor(GxEPD_WHITE);
+
+        const int16_t margin = 20;
+        int16_t y = 200;
+
+        u8g2.setFont(u8g2_font_helvB18_tf);
+        u8g2.setCursor(margin, y);
+        u8g2.print("Firmware ist aktuell");
+
+        y += 40;
+        u8g2.setFont(u8g2_font_helvB10_tf);
+        u8g2.setCursor(margin, y);
+        u8g2.printf("Version: %s", currentVersion);
+    } while (display.nextPage());
+}

--- a/src/ota/ota_manager.cpp
+++ b/src/ota/ota_manager.cpp
@@ -3,6 +3,8 @@
 #include "util/timing_manager.h"
 #include "ota/ota_manager.h"
 #include "ota/ota_update.h"
+#include "display/display_manager.h"
+#include "build_config.h"
 #include <ctime>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -19,25 +21,25 @@ static const char* TAG = "OTA_MANAGER";
 // so the caller will never be unblocked in that case.
 
 static TaskHandle_t s_callerTask = nullptr;
+static OTAResult s_otaResult = OTA_UPDATE_FAILED;
 
 static void otaTask(void* param) {
-    check_ota_update();
+    s_otaResult = check_ota_update();
 
     // Notify the caller that OTA finished without a reboot (no update / error)
-    // Use a local copy of the handle in case of race conditions
     TaskHandle_t caller = s_callerTask;
-    s_callerTask = nullptr; // clear before notify to prevent double-notify
+    s_callerTask = nullptr;
 
     if (caller != nullptr) {
         xTaskNotifyGive(caller);
     }
 
-    // Delete this task
     vTaskDelete(nullptr);
 }
 
-static void runOtaInDedicatedTask() {
+static OTAResult runOtaInDedicatedTask() {
     s_callerTask = xTaskGetCurrentTaskHandle();
+    s_otaResult = OTA_UPDATE_FAILED;
 
     BaseType_t created = xTaskCreate(
         otaTask,
@@ -50,16 +52,15 @@ static void runOtaInDedicatedTask() {
 
     if (created != pdPASS) {
         ESP_LOGE(TAG, "Failed to create OTA task – running inline (may stack overflow)");
-        check_ota_update();
-        return;
+        return check_ota_update();
     }
 
     // Block indefinitely; if OTA succeeds the device reboots and we never wake.
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+    return s_otaResult;
 }
 
 // Set to true when the user explicitly triggers OTA via Button 3 long press.
-// Lives in normal RAM — valid only within the current boot, not across deep sleep.
 static bool userRequestedUpdate = false;
 
 namespace OTAManager {
@@ -69,7 +70,6 @@ namespace OTAManager {
     }
 
     bool shouldCheckForUpdate() {
-        // User explicitly triggered OTA via button — bypass schedule and config flag
         if (userRequestedUpdate) {
             ESP_LOGI(TAG, "User-requested OTA update – bypassing schedule check");
             return true;
@@ -77,20 +77,17 @@ namespace OTAManager {
 
         RTCConfigData& config = ConfigManager::getConfig();
 
-        // Check if OTA is enabled
         if (!config.otaEnabled) {
             ESP_LOGD(TAG, "OTA automatic updates are disabled");
             return false;
         }
 
-        // Get current time
         tm timeinfo = {};
         if (!TimeManager::getCurrentLocalTime(timeinfo)) {
             ESP_LOGW(TAG, "Failed to get current time for OTA check");
             return false;
         }
 
-        // Parse configured OTA check time (format: "HH:MM")
         int configHour = 0;
         int configMinute = 0;
         if (sscanf(config.otaCheckTime, "%d:%d", &configHour, &configMinute) != 2) {
@@ -98,11 +95,9 @@ namespace OTAManager {
             return false;
         }
 
-        // Get current time
         int currentHour = timeinfo.tm_hour;
         int currentMinute = timeinfo.tm_min;
 
-        // Check if current time is within 1 minute tolerance of configured time
         bool isTimeMatch = (currentHour == configHour &&
             abs(currentMinute - configMinute) <= 1);
 
@@ -117,24 +112,38 @@ namespace OTAManager {
         return false;
     }
 
-    void checkAndApplyUpdate() {
-        if (shouldCheckForUpdate()) {
-            ESP_LOGI(TAG, "Starting OTA update check...");
-
-            // Reset user-request flag before running so normal scheduling
-            // is not affected if the OTA check completes without a restart
-            userRequestedUpdate = false;
-
-            runOtaInDedicatedTask();
-
-            // Mark OTA check timestamp to prevent repeated checks
-            time_t now;
-            time(&now);
-            TimingManager::setLastOTACheck((uint32_t)now);
-
-            // Note: If update is found and installed, device will restart
-            // If no update or update fails, execution continues normally
+    bool checkAndApplyUpdate() {
+        if (!shouldCheckForUpdate()) {
+            return false;
         }
+
+        ESP_LOGI(TAG, "Starting OTA update check...");
+        bool wasUserRequest = userRequestedUpdate;
+        userRequestedUpdate = false;
+
+        OTAResult result = runOtaInDedicatedTask();
+
+        // Mark OTA check timestamp
+        time_t now;
+        time(&now);
+        TimingManager::setLastOTACheck((uint32_t)now);
+
+        // Show display feedback only for user-triggered requests
+        if (wasUserRequest && result == OTA_UP_TO_DATE) {
+            DisplayManager::displayOTAUpToDate(FIRMWARE_VERSION);
+
+            // Set temporary mode so device sleeps ~120s then returns to configured display
+            RTCConfigData& config = ConfigManager::getConfig();
+            config.inTemporaryMode = true;
+            config.temporaryDisplayMode = config.displayMode;
+            time_t t;
+            time(&t);
+            config.temporaryModeActivationTime = (uint32_t)t;
+
+            return true; // Signal caller to skip normal rendering
+        }
+
+        return false;
     }
 } // namespace OTAManager
 

--- a/src/ota/ota_update.cpp
+++ b/src/ota/ota_update.cpp
@@ -10,6 +10,7 @@
 #include <StreamUtils.h>
 #include "build_config.h"
 #include "ota/version_helper.h"
+#include "display/display_manager.h"
 
 static const char* TAG = "OTA_UPDATE";
 
@@ -136,10 +137,10 @@ static bool resolveFirmwareUrl(const char* originalUrl, char* outUrl, size_t out
 }
 
 
-void check_ota_update() {
+OTAResult check_ota_update() {
     ReleaseInfo release;
     if (!getLatestReleaseFromGitHub(release)) {
-        return;
+        return OTA_UPDATE_FAILED;
     }
 
     SemanticVersion current = SemanticVersion::parse(FIRMWARE_VERSION);
@@ -147,7 +148,7 @@ void check_ota_update() {
 
     if (!doUpdate) {
         ESP_LOGI(TAG, "Firmware is up to date (%s)", current.toString().c_str());
-        return;
+        return OTA_UP_TO_DATE;
     }
 
     ESP_LOGI(TAG, "Update available: %s -> %s",
@@ -176,18 +177,21 @@ void check_ota_update() {
 
     ESP_LOGI(TAG, "Starting OTA download from: %s", directUrl);
 
+    // Show update progress on display
+    DisplayManager::displayOTAProgress(current.toString().c_str(), release.version.toString().c_str());
+
     // Use direct OTA API for full control over the process
     esp_http_client_handle_t client = esp_http_client_init(&ota_client_config);
     if (!client) {
         ESP_LOGE(TAG, "Failed to init HTTP client for OTA");
-        return;
+        return OTA_UPDATE_FAILED;
     }
 
     esp_err_t err = esp_http_client_open(client, 0);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to open HTTP connection: %s", esp_err_to_name(err));
         esp_http_client_cleanup(client);
-        return;
+        return OTA_UPDATE_FAILED;
     }
 
     int content_length = esp_http_client_fetch_headers(client);
@@ -198,14 +202,14 @@ void check_ota_update() {
         ESP_LOGE(TAG, "Unexpected HTTP status: %d", status_code);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
-        return;
+        return OTA_UPDATE_FAILED;
     }
 
     if (content_length <= 0) {
         ESP_LOGE(TAG, "Invalid content length: %d", content_length);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
-        return;
+        return OTA_UPDATE_FAILED;
     }
 
     // Get the next OTA partition to write to
@@ -214,7 +218,7 @@ void check_ota_update() {
         ESP_LOGE(TAG, "Failed to get update partition");
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
-        return;
+        return OTA_UPDATE_FAILED;
     }
     ESP_LOGI(TAG, "Writing to partition: %s (offset 0x%lx, size 0x%lx)",
              update_partition->label, update_partition->address, update_partition->size);
@@ -226,7 +230,7 @@ void check_ota_update() {
         ESP_LOGE(TAG, "esp_ota_begin failed: %s", esp_err_to_name(err));
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
-        return;
+        return OTA_UPDATE_FAILED;
     }
     ESP_LOGI(TAG, "OTA begin OK, handle: 0x%lx", (unsigned long)ota_handle);
 
@@ -237,7 +241,7 @@ void check_ota_update() {
         esp_ota_abort(ota_handle);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
-        return;
+        return OTA_UPDATE_FAILED;
     }
 
     int total_read = 0;
@@ -250,7 +254,7 @@ void check_ota_update() {
             esp_ota_abort(ota_handle);
             esp_http_client_close(client);
             esp_http_client_cleanup(client);
-            return;
+            return OTA_UPDATE_FAILED;
         }
         total_read += read_len;
         if (total_read % 102400 < 4096) {
@@ -267,7 +271,7 @@ void check_ota_update() {
     if (read_len < 0) {
         ESP_LOGE(TAG, "HTTP read error: %d", read_len);
         esp_ota_abort(ota_handle);
-        return;
+        return OTA_UPDATE_FAILED;
     }
 
     ESP_LOGI(TAG, "Download complete: %d bytes", total_read);
@@ -276,20 +280,21 @@ void check_ota_update() {
     err = esp_ota_end(ota_handle);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_ota_end failed: %s", esp_err_to_name(err));
-        return;
+        return OTA_UPDATE_FAILED;
     }
 
     // Set boot partition
     err = esp_ota_set_boot_partition(update_partition);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_ota_set_boot_partition failed: %s", esp_err_to_name(err));
-        return;
+        return OTA_UPDATE_FAILED;
     }
 
     ESP_LOGI(TAG, "OTA OK – rebooting...");
     printf("OTA OK, restarting...\n");
     delay(500);
     esp_restart();
+    return OTA_UPDATE_FAILED; // unreachable, but satisfies compiler
 }
 
 


### PR DESCRIPTION
- Display 'Firmware-Update: vX.Y.Z → vA.B.C' during download
- Display 'Firmware ist aktuell' for 2 min when already up to date
- Silent on failure (proceeds to sleep)
- No display change for scheduled nightly checks