### PR TITLE
Improve WiFiManager captive portal UX

### DIFF
--- a/src/util/wifi_manager.cpp
+++ b/src/util/wifi_manager.cpp
@@ -46,6 +46,14 @@ void MyWiFiManager::setupWiFiAccessPointAndRestart(WiFiManager& wm) {
     wm.setTitle("MyStation WiFi Setup");
     wm.setCountry("DE");
 
+    // Redirect root page to /wifi so captive portal shows SSID list immediately
+    wm.setWebServerCallback([&wm]() {
+        wm.server->on("/", HTTP_GET, [&wm]() {
+            wm.server->sendHeader("Location", "/wifi", true);
+            wm.server->send(302, "text/plain", "");
+        });
+    });
+
     // Start AP and wait for WiFi configuration
     String apName = Util::getUniqueSSID("MyStation");
     ESP_LOGI(TAG, "Starting AP with SSID: %s", apName.c_str());

--- a/src/util/wifi_manager.cpp
+++ b/src/util/wifi_manager.cpp
@@ -46,6 +46,17 @@ void MyWiFiManager::setupWiFiAccessPointAndRestart(WiFiManager& wm) {
     wm.setTitle("MyStation WiFi Setup");
     wm.setCountry("DE");
 
+    // Custom styling — soft background, rounded buttons, modern look
+    wm.setCustomHeadElement(
+        "<style>"
+        "body{background:#f0f4f8;font-family:-apple-system,sans-serif;}"
+        "button,input[type='button'],input[type='submit']{background-color:#1565c0;border-radius:6px;}"
+        "h1,h3{color:#1a237e;}"
+        "div a{color:#1565c0;font-weight:bold;}"
+        "input,select{border:1px solid #ccc;border-radius:4px;}"
+        "</style>"
+    );
+
     // Redirect root page to /wifi so captive portal shows SSID list immediately
     wm.setWebServerCallback([&wm]() {
         wm.server->on("/", HTTP_GET, [&wm]() {


### PR DESCRIPTION
## Changes

1. **Redirect root to /wifi** — Users see the WiFi network list immediately when the captive portal opens, instead of having to click a button first.

2. **Modern styling** — Soft blue-gray background, rounded buttons, system font, subtle input borders. Less dry, more polished.

## Before
- Root page shows a single 'Configure WiFi' button
- Plain white background, default styling

## After
- SSID list shown immediately on portal open
- Clean modern look with blue accent colors