### PR TITLE
fix: buffer overflow in forecast parsing and API key leak in logs

### DIFF
--- a/include/api/dwd_weather_api.h
+++ b/include/api/dwd_weather_api.h
@@ -42,7 +42,7 @@ struct WeatherInfo {
     int hourlyForecastCount;
 
     // Daily forecast
-    WeatherDailyForecast dailyForecast[7]; // 14-day forecast
+    WeatherDailyForecast dailyForecast[7]; // 7-day forecast
     int dailyForecastCount;
 };
 

--- a/src/api/dwd_weather_api.cpp
+++ b/src/api/dwd_weather_api.cpp
@@ -170,8 +170,8 @@ bool getGeneralWeatherFull(float lat, float lon, WeatherInfo& weather) {
 
 
                 int count = 0;
-                // Max 14-day forecast
-                for (size_t i = 0; i < times.size() && count < 14; ++i) {
+                // Max 7-day forecast (array size is 7)
+                for (size_t i = 0; i < times.size() && count < 7; ++i) {
                     safeStringCopy(weather.dailyForecast[count].time, times[i].as<String>(), TIME_STRING_LENGTH);
 
                     // Extract sunrise/sunset times

--- a/src/api/google_api.cpp
+++ b/src/api/google_api.cpp
@@ -33,7 +33,7 @@ bool getLocationFromGoogle(float& lat, float& lon) {
     String url = "https://www.googleapis.com/geolocation/v1/geolocate?key=" + String(
         AESCrypto::getGoogleAPIKey().c_str());
 
-    ESP_LOGI(TAG, "Requesting location from Google: %s", url.c_str());
+    ESP_LOGI(TAG, "Requesting location from Google Geolocation API");
     http.begin(url);
     http.addHeader("Content-Type", "application/json");
     int httpCode = http.POST(wifiJson);

--- a/src/display/common_footer.cpp
+++ b/src/display/common_footer.cpp
@@ -2,6 +2,7 @@
 #include "display/text_utils.h"
 #include "util/time_manager.h"
 #include "util/battery_manager.h"
+#include "util/timing_manager.h"
 #include <icons.h>
 #include <WiFi.h>
 #include "global_instances.h"


### PR DESCRIPTION
## Critical Fixes

### 1. Buffer overflow in daily forecast parsing
`dailyForecast[7]` array was indexed up to 14 in the parse loop. If Open-Meteo returned more than 7 days, this would write past the array bounds — potential crash or memory corruption.

**Fix:** `count < 14` → `count < 7`

### 2. Google API key logged in plaintext
The full URL including the decrypted API key was logged via `ESP_LOGI`. Anyone with serial access could read the key.

**Fix:** Log only that the request is being made, without the URL.

### Bonus: missing include for debug builds
`common_footer.cpp` used `TimingManager` in a `DEBUG_ONLY()` block without the include — caused build failure in debug environments.

## Tested
- `esp32-s3-e1001-debug`: SUCCESS
- `esp32-s3-e1001-production`: SUCCESS