### PR TITLE
fix: code review cleanups

### DIFF
--- a/include/api/dwd_weather_api.h
+++ b/include/api/dwd_weather_api.h
@@ -3,7 +3,7 @@
 #define TIME_STRING_LENGTH 17      // "2025-08-25T22:00" + null terminator
 #define TIME_SHORT_LENGTH 6        // "22:00" + null terminator
 
-struct WeatherHoulyForecast {
+struct WeatherHourlyForecast {
     char time[TIME_STRING_LENGTH];
     float temperature;
     int weatherCode;
@@ -38,7 +38,7 @@ struct WeatherInfo {
     int weatherCode;
 
     // Hourly forecast
-    WeatherHoulyForecast hourlyForecast[13]; // 1hour past and 12-hour forecast
+    WeatherHourlyForecast hourlyForecast[13]; // 1hour past and 12-hour forecast
     int hourlyForecastCount;
 
     // Daily forecast

--- a/src/activity/activity_manager.cpp
+++ b/src/activity/activity_manager.cpp
@@ -53,7 +53,7 @@ void ActivityManager::onInit() {
     SystemInit::handleButtonLongPressActions();
     SystemInit::initDisplay();
     SystemInit::initFont();
-    BatteryManager::init();;
+    BatteryManager::init();
 #if SHOW_BATTERY_STATUS
     float batteryVoltage = BatteryManager::getBatteryVoltage();
     // 0V means no battery connected (USB-only power) — skip the check

--- a/src/api/dwd_weather_api.cpp
+++ b/src/api/dwd_weather_api.cpp
@@ -23,10 +23,8 @@ String getCityFromLatLon(float lat, float lon) {
     int httpCode = http.GET();
     String city = "";
     if (httpCode == HTTP_CODE_OK) {
-        String payload = http.getString();
-        ESP_LOGD("DWD_CITY", "Nominatim payload: %s", payload.c_str());
         DynamicJsonDocument doc(2048);
-        DeserializationError error = deserializeJson(doc, payload);
+        DeserializationError error = deserializeJson(doc, http.getStream());
         if (!error && doc.containsKey("address")) {
             if (doc["address"].containsKey("city")) {
                 city = doc["address"]["city"].as<String>();
@@ -107,9 +105,8 @@ bool getGeneralWeatherFull(float lat, float lon, WeatherInfo& weather) {
     http.begin(url);
     int httpCode = http.GET();
     if (httpCode > 0) {
-        String payload = http.getString();
         DynamicJsonDocument doc(8192);
-        DeserializationError error = deserializeJson(doc, payload);
+        DeserializationError error = deserializeJson(doc, http.getStream());
         if (!error) {
             // Parse current weather
             if (doc.containsKey("current")) {

--- a/src/api/rmv_api.cpp
+++ b/src/api/rmv_api.cpp
@@ -106,6 +106,7 @@ void getNearbyStops(float lat, float lon) {
     }
     ESP_LOGI(TAG, "Requesting nearby stops: %s", urlForLog.c_str());
     http.begin(url);
+    http.setTimeout(10000);
     int httpCode = http.GET();
     if (httpCode > 0) {
         String payload = http.getString();
@@ -263,6 +264,7 @@ bool getDepartureFromRMV(const char* stopId, DepartureData& departData) {
     ESP_LOGI(TAG, "Walking time: %d minutes, departure time filter: %s", config.walkingTime, departureTime.c_str());
 
     http.begin(url);
+    http.setTimeout(10000);
 
     const char* keys[] = {"Transfer-Encoding"};
     http.collectHeaders(keys, 1);
@@ -301,10 +303,11 @@ bool getDepartureFromRMV(const char* stopId, DepartureData& departData) {
 
     http.end();
 
-    // Pretty print to string
+#if CORE_DEBUG_LEVEL >= 4
     String prettyJson;
     serializeJsonPretty(doc, prettyJson);
     ESP_LOGD(TAG, "JSON Document (pretty):\n%s", prettyJson.c_str());
+#endif
 
     // Check actual memory usage
     ESP_LOGI(TAG, "Memory used: %u/%u bytes", doc.memoryUsage(), doc.capacity());

--- a/src/display/common_footer.cpp
+++ b/src/display/common_footer.cpp
@@ -2,6 +2,7 @@
 #include "display/text_utils.h"
 #include "util/time_manager.h"
 #include "util/battery_manager.h"
+#include "util/timing_manager.h"
 #include <icons.h>
 #include <WiFi.h>
 #include "global_instances.h"
@@ -35,7 +36,7 @@ void CommonFooter::drawFooter(int16_t x, int16_t y, int16_t h, uint8_t elements)
     }
 
     DEBUG_ONLY(
-        String sleepTime = "Sleep Time: " + String(TimingManager::getNextSleepDurationSeconds()) + "s";;
+        String sleepTime = "Sleep Time: " + String(TimingManager::getNextSleepDurationSeconds()) + "s";
         TextUtils::printTextAtWithMargin(currentX, footerY, sleepTime);
     );
 }

--- a/src/util/timing_manager.cpp
+++ b/src/util/timing_manager.cpp
@@ -373,7 +373,7 @@ uint16_t TimingManager::getCurrentMin() {
     time_t now = GET_CURRENT_TIME();
     tm timeInfo;
     localtime_r(&now, &timeInfo);
-    return timeInfo.tm_hour * 60 + timeInfo.tm_min;;
+    return timeInfo.tm_hour * 60 + timeInfo.tm_min;
 }
 
 uint16_t TimingManager::getSleepStartMin() {


### PR DESCRIPTION
## Fixes

- **Extra semicolons**: removed in timing_manager.cpp, activity_manager.cpp, common_footer.cpp
- **HTTP timeout**: added `http.setTimeout(10000)` to both RMV API calls (nearby stops + departures)
- **Typo**: `WeatherHoulyForecast` → `WeatherHourlyForecast`
- **Production perf**: wrapped `serializeJsonPretty` in `#if CORE_DEBUG_LEVEL >= 4` so it doesn't allocate in production
- **Memory**: weather API now uses `http.getStream()` directly instead of loading full response into a String first (saves ~8KB heap)
- **Build fix**: added missing `timing_manager.h` include for debug builds

## Tested
- `esp32-s3-e1001-debug`: SUCCESS
- `native` tests: 34/34 PASSED