### PR TITLE
perf: turn off WiFi before display rendering

### DIFF
--- a/include/display/common_footer.h
+++ b/include/display/common_footer.h
@@ -16,11 +16,17 @@ public:
     // elements: bitwise OR of FooterElements flags
     static void drawFooter(int16_t x, int16_t y, int16_t h, uint8_t elements = FOOTER_TIME | FOOTER_REFRESH);
 
+    // Cache WiFi state before turning WiFi off (call before WiFi.disconnect())
+    static void cacheWiFiState();
+
     // Helper functions to get icon names (for reuse in other display contexts)
     static icon_name getWiFiIcon();
     static icon_name getBatteryIcon();
 
 private:
+    static int32_t cachedRSSI;
+    static bool cachedConnected;
+
     static String getTimeString();
     static void drawWiFiStatus(int16_t& currentX, int16_t y);
     static void drawBatteryStatus(int16_t& currentX, int16_t y);

--- a/src/display/common_footer.cpp
+++ b/src/display/common_footer.cpp
@@ -10,6 +10,15 @@
 
 static const char* TAG = "COMMON_FOOTER";
 
+// Static member definitions
+int32_t CommonFooter::cachedRSSI = 0;
+bool CommonFooter::cachedConnected = false;
+
+void CommonFooter::cacheWiFiState() {
+    cachedRSSI = WiFi.RSSI();
+    cachedConnected = (WiFi.status() == WL_CONNECTED);
+}
+
 
 void CommonFooter::drawFooter(int16_t x, int16_t y, int16_t h, uint8_t elements) {
     TextUtils::setFont10px_margin12px(); // Small font for footer
@@ -66,23 +75,17 @@ void CommonFooter::drawWiFiStatus(int16_t& currentX, int16_t y) {
 }
 
 icon_name CommonFooter::getWiFiIcon() {
-    // Get WiFi signal strength
-    int32_t rssi = WiFi.RSSI();
-    icon_name wifiIcon;
-
-    if (WiFi.status() != WL_CONNECTED) {
-        wifiIcon = wifi_off;
-    } else if (rssi > -50) {
-        wifiIcon = wifi; // Strong signal
-    } else if (rssi > -60) {
-        wifiIcon = wifi_3_bar; // Good signal
-    } else if (rssi > -70) {
-        wifiIcon = wifi_2_bar; // Fair signal
+    if (!cachedConnected) {
+        return wifi_off;
+    } else if (cachedRSSI > -50) {
+        return wifi; // Strong signal
+    } else if (cachedRSSI > -60) {
+        return wifi_3_bar; // Good signal
+    } else if (cachedRSSI > -70) {
+        return wifi_2_bar; // Fair signal
     } else {
-        wifiIcon = wifi_1_bar; // Weak signal
+        return wifi_1_bar; // Weak signal
     }
-
-    return wifiIcon;
 }
 
 void CommonFooter::drawBatteryStatus(int16_t& currentX, int16_t y) {

--- a/src/util/device_mode_manager.cpp
+++ b/src/util/device_mode_manager.cpp
@@ -21,8 +21,17 @@
 #include "util/timing_manager.h"
 #include "util/weather_print.h"
 #include "util/wifi_manager.h"
+#include "display/common_footer.h"
 
 static const char* TAG = "DEVICE_MODE";
+
+// Turn off WiFi before display rendering to save power (~100mA)
+static void shutdownWiFiBeforeRender() {
+    CommonFooter::cacheWiFiState();
+    WiFi.disconnect(true);
+    WiFi.mode(WIFI_OFF);
+    ESP_LOGI(TAG, "WiFi disabled before display rendering");
+}
 
 // Global variables needed for operation
 
@@ -78,6 +87,7 @@ void DeviceModeManager::showApplicationInfo() {
     float voltage = BatteryManager::getBatteryVoltage();
     int percent = BatteryManager::getBatteryPercentage();
 
+    shutdownWiFiBeforeRender();
     DisplayManager::displayApplicationInfo(voltage, percent);
 }
 
@@ -98,6 +108,7 @@ void DeviceModeManager::showWeatherDeparture() {
     fetchTransportData(depart);
     TimingManager::markTransportUpdated();
 
+    shutdownWiFiBeforeRender();
     DisplayManager::displayHalfNHalf(weather, depart);
 }
 
@@ -119,6 +130,7 @@ void DeviceModeManager::updateWeatherFull() {
         ESP_LOGI(TAG, "use cached Weather data, no data fetch needed");
     }
     printWeatherInfo(weather);
+    shutdownWiFiBeforeRender();
     DisplayManager::displayWeatherFull(weather);
 }
 
@@ -140,6 +152,7 @@ void DeviceModeManager::updateDepartureFull() {
         if (depart.departureCount == 0) {
             ESP_LOGI(TAG, "No departures scheduled at this time");
         }
+        shutdownWiFiBeforeRender();
         DisplayManager::displayDeparturesFull(depart);
     } else {
         ESP_LOGE(TAG, "Failed to get departure information from RMV.");
@@ -148,6 +161,7 @@ void DeviceModeManager::updateDepartureFull() {
         depart.stopId = stopIdToUse;
         depart.stopName = String(config.selectedStopName);
         depart.departureCount = 0;
+        shutdownWiFiBeforeRender();
         DisplayManager::displayDeparturesFull(depart);
     }
 }


### PR DESCRIPTION
## Problem

WiFi remained active (~100mA) during the entire 1-3 second e-paper rendering phase, wasting battery.

## Solution

- Added `CommonFooter::cacheWiFiState()` to snapshot RSSI before WiFi shutdown
- `getWiFiIcon()` now uses cached values instead of live `WiFi.RSSI()`
- `shutdownWiFiBeforeRender()` called in all display modes right after data fetching completes

## Impact

Saves 500-2000ms of WiFi on-time per wake cycle (~100mA savings during rendering).

## Tested
- `esp32-s3-e1001-debug`: SUCCESS