### PR TITLE
perf: misc optimizations (stack URLs, init-once, debug-only logs)

### DIFF
--- a/src/api/rmv_api.cpp
+++ b/src/api/rmv_api.cpp
@@ -11,6 +11,7 @@
 #include "config/config_manager.h"
 #include "config/config_page_data.h"
 #include "sec/aes_crypto.h"
+#include "build_config.h"
 #include <time.h>
 
 static const char* TAG = "RMV_API";
@@ -92,18 +93,20 @@ void getNearbyStops(float lat, float lon) {
     // Use static utility method for secure API key decryption (no caching)
     std::string decrypted = AESCrypto::getRMVAPIKey();
 
-    String url = "https://www.rmv.de/hapi/location.nearbystops?accessId=" + String(decrypted.c_str()) +
-        "&originCoordLat=" + String(lat, 6) +
-        "&originCoordLong=" + String(lon, 6) +
-        "&format=json&maxNo=7";
-    String urlForLog = url;
-    int keyPos = urlForLog.indexOf("accessId=");
-    if (keyPos != -1) {
-        int keyEnd = urlForLog.indexOf('&', keyPos);
-        if (keyEnd == -1) keyEnd = urlForLog.length();
-        urlForLog.replace(urlForLog.substring(keyPos, keyEnd), "accessId=***");
-    }
-    ESP_LOGI(TAG, "Requesting nearby stops: %s", urlForLog.c_str());
+    char url[256];
+    snprintf(url, sizeof(url),
+        "https://www.rmv.de/hapi/location.nearbystops?accessId=%s&originCoordLat=%.6f&originCoordLong=%.6f&format=json&maxNo=7",
+        decrypted.c_str(), lat, lon);
+    DEBUG_ONLY(
+        String urlForLog = url;
+        int keyPos = urlForLog.indexOf("accessId=");
+        if (keyPos != -1) {
+            int keyEnd = urlForLog.indexOf('&', keyPos);
+            if (keyEnd == -1) keyEnd = urlForLog.length();
+            urlForLog.replace(urlForLog.substring(keyPos, keyEnd), "accessId=***");
+        }
+        ESP_LOGI(TAG, "Requesting nearby stops: %s", urlForLog.c_str());
+    );
     http.begin(url);
     http.setTimeout(10000);
     int httpCode = http.GET();
@@ -245,21 +248,22 @@ bool getDepartureFromRMV(const char* stopId, DepartureData& departData) {
     // Calculate departure time and date including walking time for API request
     String departureTime = calculateDepartureTime(config.walkingTime);
 
-    String url = "https://www.rmv.de/hapi/departureBoard?accessId=" + String(decrypted.c_str()) +
-        "&id=" + encodedId +
-        "&format=json&maxJourneys=22&duration=90" + productsParam +
-        "&time=" + departureTime;
+    char url[512];
+    snprintf(url, sizeof(url),
+        "https://www.rmv.de/hapi/departureBoard?accessId=%s&id=%s&format=json&maxJourneys=22&duration=90%s&time=%s",
+        decrypted.c_str(), encodedId.c_str(), productsParam.c_str(), departureTime.c_str());
 
-    String urlForLog = url;
-    int keyPos = urlForLog.indexOf("accessId=");
-    if (keyPos != -1) {
-        int keyEnd = urlForLog.indexOf('&', keyPos);
-        if (keyEnd == -1) keyEnd = urlForLog.length();
-        urlForLog.replace(urlForLog.substring(keyPos, keyEnd), "accessId=***");
-    }
-
-    ESP_LOGI(TAG, "Requesting departure board: %s", urlForLog.c_str());
-    ESP_LOGI(TAG, "Walking time: %d minutes, departure time filter: %s", config.walkingTime, departureTime.c_str());
+    DEBUG_ONLY(
+        String urlForLog = url;
+        int keyPos = urlForLog.indexOf("accessId=");
+        if (keyPos != -1) {
+            int keyEnd = urlForLog.indexOf('&', keyPos);
+            if (keyEnd == -1) keyEnd = urlForLog.length();
+            urlForLog.replace(urlForLog.substring(keyPos, keyEnd), "accessId=***");
+        }
+        ESP_LOGI(TAG, "Requesting departure board: %s", urlForLog.c_str());
+        ESP_LOGI(TAG, "Walking time: %d minutes, departure time filter: %s", config.walkingTime, departureTime.c_str());
+    );
 
     http.begin(url);
     http.setTimeout(10000);
@@ -275,7 +279,8 @@ bool getDepartureFromRMV(const char* stopId, DepartureData& departData) {
         return false;
     }
 
-    initDepartureFilter();
+    static bool filterReady = false;
+    if (!filterReady) { initDepartureFilter(); filterReady = true; }
 
     // Create the raw and decoded stream
     Stream& rawStream = http.getStream();

--- a/src/display/weather_graph.cpp
+++ b/src/display/weather_graph.cpp
@@ -258,7 +258,7 @@ void WeatherGraph::drawTemperatureLine(const WeatherInfo& weather,
         int16_t p3y = (i < dataPoints - 2) ? tempY[i + 2] : tempY[i + 1];
 
         // Draw smooth curve between p1 and p2 using many small segments
-        int smoothSteps = 16; // Higher number = smoother curve
+        int smoothSteps = 8; // Smooth curve (8 steps sufficient for 1-bit e-paper)
 
         for (int step = 0; step < smoothSteps; step++) {
             // Calculate interpolation parameter (0.0 to 1.0)


### PR DESCRIPTION
## Changes

1. **Stack-based URL building** — RMV API URLs use `snprintf()` into `char[512]`/`char[256]` instead of String concatenation. Zero heap allocation, no fragmentation.

2. **Filter init-once** — `initDepartureFilter()` now only runs on first call via static guard.

3. **Debug-only URL masking** — String copy + indexOf + replace for log redaction wrapped in `DEBUG_ONLY()`. Skipped entirely in production builds.

4. **Spline steps 16→8** — Temperature curve uses 8 Catmull-Rom steps instead of 16. Visually identical on 1-bit e-paper, halves the floating-point computation.

## Tested
- `esp32-s3-e1001-debug`: SUCCESS
- `esp32-s3-e1001-production`: SUCCESS