### PR TITLE
feat: show device ID on info page

### DIFF
--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -379,7 +379,8 @@ void DisplayManager::displayApplicationInfo(float batteryVoltage, int batteryPer
         u8g2.printf("Version : %s", FIRMWARE_VERSION);
         y += lhSmall;
         u8g2.setCursor(margin, y);
-        u8g2.printf("Board   : %s", boardName);
+        uint32_t chipId = (uint32_t)ESP.getEfuseMac() & 0xFFFFFF;
+        u8g2.printf("Board   : %s [%06X]", boardName, chipId);
         y += lhSmall;
         u8g2.setCursor(margin, y);
         {


### PR DESCRIPTION
Shows the device chip ID (same hex suffix as Phase 1 WiFi AP name `MyStation-XXXXXX`) next to the board name on the Device Info screen.

```
Board   : PCB E1001 (ESP32-S3) [A1B2C3]
```

Helps identify which physical device you're looking at.