### PR TITLE
fix: device info page always shows Excellent WiFi signal

### DIFF
--- a/include/display/common_footer.h
+++ b/include/display/common_footer.h
@@ -19,6 +19,9 @@ public:
     // Cache WiFi state before turning WiFi off (call before WiFi.disconnect())
     static void cacheWiFiState();
 
+    // Get cached RSSI value (valid after cacheWiFiState() is called)
+    static int32_t getCachedRSSI() { return cachedRSSI; }
+
     // Helper functions to get icon names (for reuse in other display contexts)
     static icon_name getWiFiIcon();
     static icon_name getBatteryIcon();

--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -6,6 +6,7 @@
 #include "display/transport_display.h"
 #include "display/weather_general_half.h"
 #include "display/weather_general_full.h"
+#include "display/common_footer.h"
 #include "display/qr_code_helper.h"
 #include "util/util.h"
 
@@ -505,7 +506,7 @@ void DisplayManager::displayApplicationInfo(float batteryVoltage, int batteryPer
         ry += lhSmall;
         u8g2.setCursor(col2, ry);
         {
-            int rssi = WiFi.RSSI();
+            int rssi = CommonFooter::getCachedRSSI();
             const char* quality = "Very weak";
             if (rssi >= -50) quality = "Excellent";
             else if (rssi >= -60) quality = "Good";


### PR DESCRIPTION
## Bug

`WiFi.RSSI()` was called after `shutdownWiFiBeforeRender()` already disconnected WiFi. Returns 0 when disconnected, and `0 >= -50` evaluates to true -> always shows "Excellent (0 dBm)".

## Fix

Use `CommonFooter::getCachedRSSI()` which is captured while WiFi is still connected (before shutdown). Added a public getter to `CommonFooter`.