### PR TITLE
fix: stop ID encoding error causing save failure

### DIFF
--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -573,7 +573,7 @@
               stopSelect.innerHTML = '<option value="">Bitte wählen...</option>';
               data.stops.forEach(function(s) {
                 var opt = document.createElement('option');
-                opt.value = encodeURIComponent(s.id);
+                opt.value = s.id;
                 opt.textContent = s.name + '   (' + s.dist + 'm)';
                 stopSelect.appendChild(opt);
               });

--- a/src/config/config_page.cpp
+++ b/src/config/config_page.cpp
@@ -36,8 +36,8 @@ static String renderConfigPageHtml() {
     if (pageData.getStopCount() > 0) {
         stopsHtml = "<option value=''>Bitte wählen...</option>";
         for (size_t i = 0; i < pageData.getStopCount(); ++i) {
-            String encodedId = Util::urlEncode(pageData.getStopId(i));
-            stopsHtml += "<option value='" + encodedId + "'>" + pageData.getStopName(i) + "   (" +
+            String stopId = pageData.getStopId(i);
+            stopsHtml += "<option value='" + stopId + "'>" + pageData.getStopName(i) + "   (" +
                 pageData.getStopDistance(i) + "m)</option>";
         }
     } else {
@@ -119,12 +119,6 @@ void handleSaveConfig(WebServer& server) {
     if (err) {
         server.send(400, "text/plain", "Invalid JSON");
         return;
-    }
-
-    // Decode stopId if present
-    if (doc["stopId"].is<const char*>()) {
-        String stopId = doc["stopId"].as<String>();
-        doc["stopId"] = Util::urlDecode(stopId);
     }
 
     ESP_LOGI(TAG, "Saving configuration from web interface");


### PR DESCRIPTION
## Bug

Selecting a departure stop and saving configuration failed because the stop ID was incorrectly URL-encoded.

## Root Cause

Stop IDs (e.g. `A=1@O=Frankfurt (Main) Hbf@X=8663785@Y=50107149@U=80@L=3006907@`) were URL-encoded before being sent in a JSON body. This is unnecessary — JSON handles these characters natively.

The encoding caused two problems:
1. JS `encodeURIComponent()` and C++ `Util::urlEncode()` encode differently (e.g. parentheses)
2. Inconsistency between AJAX path (encoded) and template path (differently encoded)

## Fix

Remove the URL encode/decode round-trip entirely. Stop IDs are now stored raw in the HTML option values and sent as-is in the JSON POST body. `JSON.stringify()` handles escaping correctly.

URL encoding remains only where actually needed: in `rmv_api.cpp` when building HTTP request URLs to the RMV API.