### PR TITLE
improve: UI tweaks for departure display

### DIFF
--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -306,11 +306,6 @@ void DisplayManager::displayPhase2AppSetup() {
         u8g2.print("4. \"Speichern\" drücken - MyStation startet automatisch neu");
         y += lineHeight;
 
-        u8g2.setFont(u8g2_font_helvB10_tf);
-        u8g2.setCursor(margin, 462);
-        u8g2.print(
-            "Hinweis: Die Konfigurationsseite braucht einige Sekunden zum Laden (Standort und Haltestellen werden ermittelt).");
-
         // === QR CODE ON RIGHT SIDE ===
         const int16_t qrX = 540; // X position for QR code (right side)
         const uint8_t qrVersion = 3; // Version 3 (29x29 modules)

--- a/src/display/transport_display.cpp
+++ b/src/display/transport_display.cpp
@@ -278,7 +278,9 @@ void TransportDisplay::drawSingleTransport(const DepartureInfo& dep, int16_t x, 
     currentX += COLUMN_PADDING + timeWidth;
     TextUtils::printTextAtTopMargin(currentX, currentY, dep.line.c_str());
     currentX += COLUMN_PADDING + lineWidth;
-    TextUtils::printTextAtTopMargin(currentX, currentY, dest.c_str());
+    int16_t destMaxWidth = (x + width) - currentX;
+    String fittedDest = TextUtils::shortenTextToFit(dest, destMaxWidth);
+    TextUtils::printTextAtTopMargin(currentX, currentY, fittedDest.c_str());
 
     // Draw track info right-aligned
     int8_t trackWidth = TextUtils::getTextWidth(dep.track.c_str());

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -99,7 +99,17 @@ String Util::shortenStationName(const String& stationName) {
 //   Input:  departure = "Frankfurt", destination = "Frankfurt Bahnhof"
 //   Output: "Bhf"
 String Util::shortenDestination(const String departure, const String destination) {
-    // Tokenize departure
+    // City qualifiers to strip after removing matching city prefix
+    static const char* cityQualifiers[] = {
+        "(Main)", "a.M.", "am Main",
+        "(Taunus)", "i.Ts.", "im Taunus",
+        "(Hessen)", "(Rhein)", "(Lahn)",
+        "(Dill)", "(Wetterau)", "(Odenwald)",
+        "(Bergstraße)", "(Vogelsberg)",
+        nullptr
+    };
+
+    // Tokenize departure (stop name)
     std::vector<String> depTokens;
     int start = 0, end = 0;
     while ((end = departure.indexOf(' ', start)) != -1) {
@@ -130,13 +140,20 @@ String Util::shortenDestination(const String departure, const String destination
         result += destTokens[j];
     }
 
-    // Apply replacements from the shared map
-    for (const auto& pair : stationReplacements) {
-        int idx = result.indexOf(pair.first);
-        while (idx != -1) {
-            result = result.substring(0, idx) + pair.second + result.substring(idx + pair.first.length());
-            idx = result.indexOf(pair.first, idx + pair.second.length());
+    // Strip city qualifiers from the beginning of the result
+    result.trim();
+    bool stripped = true;
+    while (stripped) {
+        stripped = false;
+        for (int q = 0; cityQualifiers[q] != nullptr; q++) {
+            if (result.startsWith(cityQualifiers[q])) {
+                result = result.substring(strlen(cityQualifiers[q]));
+                result.trim();
+                stripped = true;
+                break;
+            }
         }
     }
+
     return result;
 }


### PR DESCRIPTION
- Remove outdated loading time hint from config display screen
- Truncate long destination names with '...' to prevent column overlap
- Strip city qualifiers (Main, a.M., Taunus, etc.) from destination names

Example: Stop 'Frankfurt Hbf', Dest 'Frankfurt (Main) Enkheim' → shows 'Enkheim'