### PR TITLE
fix: regional weather model coverage warning and null forecast handling

### DIFF
--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -305,12 +305,12 @@
           <option value="">Automatisch (Standard, 7 Tage)</option>
           <option value="icon_seamless">DWD ICON - Deutschland (7 Tage)</option>
           <option value="ecmwf_ifs025">ECMWF - Europa (7 Tage)</option>
-          <option value="meteofrance_seamless">Meteo-France - Frankreich (4 Tage)</option>
-          <option value="meteoswiss_icon_seamless">MeteoSwiss - Schweiz (5 Tage)</option>
-          <option value="italia_meteo_arpae_icon_2i">ItaliaMeteo - Italien (3 Tage)</option>
+          <option value="meteofrance_seamless">Meteo-France - nur Frankreich (4 Tage)</option>
+          <option value="meteoswiss_icon_seamless">MeteoSwiss - nur Schweiz (5 Tage)</option>
+          <option value="italia_meteo_arpae_icon_2i">ItaliaMeteo - nur Italien (3 Tage)</option>
         </select>
       </div>
-      <div class="help-text">Hinweis: Einige Modelle liefern weniger als 7 Tage Vorhersage. Fehlende Tage werden leer angezeigt.</div>
+      <div class="help-text">Hinweis: Regionale Modelle (MeteoSwiss, ItaliaMeteo, Meteo-France) funktionieren nur innerhalb ihres Abdeckungsgebiets. Für Standorte in Deutschland empfohlen: Automatisch, DWD ICON oder ECMWF.</div>
     </div>
 
     <!-- ÖPNV Configuration Section -->

--- a/src/api/dwd_weather_api.cpp
+++ b/src/api/dwd_weather_api.cpp
@@ -137,6 +137,11 @@ bool getGeneralWeatherFull(float lat, float lon, WeatherInfo& weather) {
                 int count = 0;
                 // Max 7-day forecast (array size is 7)
                 for (size_t i = 0; i < times.size() && count < 7; ++i) {
+                    // Stop if core data is null (regional models return fewer days)
+                    if (temp_max[i].isNull() || temp_min[i].isNull()) {
+                        break;
+                    }
+
                     safeStringCopy(weather.dailyForecast[count].time, times[i].as<String>(), TIME_STRING_LENGTH);
 
                     // Extract sunrise/sunset times


### PR DESCRIPTION
MeteoSwiss model returns 400 for German locations — it only covers Switzerland.

Added coverage notes to the config UI so users know which models work for their location.