### PR TITLE
fix: WiFi icon shows weaker signal than actual

### DIFF
--- a/src/display/common_footer.cpp
+++ b/src/display/common_footer.cpp
@@ -77,11 +77,11 @@ void CommonFooter::drawWiFiStatus(int16_t& currentX, int16_t y) {
 icon_name CommonFooter::getWiFiIcon() {
     if (!cachedConnected) {
         return wifi_off;
-    } else if (cachedRSSI > -50) {
-        return wifi; // Strong signal
     } else if (cachedRSSI > -60) {
-        return wifi_3_bar; // Good signal
+        return wifi; // Strong signal
     } else if (cachedRSSI > -70) {
+        return wifi_3_bar; // Good signal
+    } else if (cachedRSSI > -80) {
         return wifi_2_bar; // Fair signal
     } else {
         return wifi_1_bar; // Weak signal


### PR DESCRIPTION
Thresholds shifted from -50/-60/-70 to -60/-70/-80 dBm to match real-world ESP32 RSSI values. A typical home WiFi signal through walls (-55 to -65 dBm) now correctly shows full/3-bar instead of 3-bar/2-bar.