### PR TITLE
docs: sync documentation with multi-board OTA and UV index changes

### DIFF
--- a/docs/developer-guide/api-integration.md
+++ b/docs/developer-guide/api-integration.md
@@ -136,6 +136,9 @@ appended to the Open-Meteo API URL when a specific model is chosen.
 **Note**: Some models provide fewer than 7 days of daily forecast. The display gracefully
 handles this by rendering only the available days (remaining space is left empty).
 
+**UV Index**: Only available in Auto mode (no `&models=` parameter). All specific models
+return `null` for `uv_index_max`. The display hides the UV section when data is unavailable.
+
 The JSON response format is identical regardless of model selection — only the data
 coverage and resolution differ.
 

--- a/docs/maintainer-guide/github-actions.md
+++ b/docs/maintainer-guide/github-actions.md
@@ -78,7 +78,7 @@ git push origin v1.2.0
 #### Job 1: Build
 
 **Environment**: Ubuntu Latest
-**Matrix Strategy**: Builds for `esp32-c3-production` environment
+**Matrix Strategy**: Builds for `esp32-s3-e1001-production` and `esp32-s3-ee04-production` environments
 
 **Steps**:
 
@@ -129,14 +129,14 @@ git push origin v1.2.0
 
 6. **Build Firmware**
    ```bash
-   pio run -e esp32-c3-production
+   pio run -e ${{ matrix.environment }}
    ```
-   Compiles firmware for ESP32-C3 production environment.
+   Compiles firmware for the specified production environment.
 
    **Output Files**:
-    - `.pio/build/esp32-c3-production/firmware.bin` - Main firmware
-    - `.pio/build/esp32-c3-production/bootloader.bin` - Bootloader
-    - `.pio/build/esp32-c3-production/partitions.bin` - Partition table
+    - `.pio/build/${{ matrix.environment }}/firmware.bin` - Main firmware (renamed to board-specific name)
+    - `.pio/build/${{ matrix.environment }}/bootloader.bin` - Bootloader
+    - `.pio/build/${{ matrix.environment }}/partitions.bin` - Partition table
     - `.pio/build/esp32-c3-production/firmware.elf` - Debug symbols
 
 7. **Create Build Info**
@@ -191,19 +191,17 @@ git push origin v1.2.0
 ### Artifacts Produced
 
 ```
-mystation-firmware-{sha}/
-├── firmware.bin              # Main application binary
-├── bootloader.bin            # ESP32 bootloader
-├── partitions.bin            # Partition table
-├── firmware.elf              # Debug symbols (for crash analysis)
-├── build_info.txt           # Build metadata
-├── config_my_station.html   # Configuration web page
-└── VERSION.txt              # Version information
+release/
+├── firmware-e1001.bin    # Firmware for PCB E1001 (ESP32-S3)
+├── firmware-ee04.bin     # Firmware for PCB EE04 (ESP32-S3)
+├── bootloader.bin        # ESP32 bootloader (for initial USB flash)
+├── partitions.bin        # Partition table (for initial USB flash)
+└── build_info.txt        # Build metadata
 ```
 
 ### Configuration
 
-**PlatformIO Default Environment**: `esp32-s3-production`
+**PlatformIO Default Environment**: `esp32-s3-e1001-production`
 
 ---
 

--- a/docs/maintainer-guide/ota-update.md
+++ b/docs/maintainer-guide/ota-update.md
@@ -29,14 +29,29 @@ only the `tag_name` , `name` and the `browser_download_url` of the release infor
     "assets": [
         {
             ...
-            "name": "firmware.bin",
+            "name": "firmware-e1001.bin",
             ...
-            "browser_download_url": "https://github.com/gogo-boot/mystation/releases/download/v0.3.0/firmware.bin"
+            "browser_download_url": "https://github.com/gogo-boot/mystation/releases/download/v0.3.0/firmware-e1001.bin"
+        },
+        {
+            ...
+            "name": "firmware-ee04.bin",
+            ...
+            "browser_download_url": "https://github.com/gogo-boot/mystation/releases/download/v0.3.0/firmware-ee04.bin"
         },
         ...
     ]
 }
 ```
+
+Each board downloads its own firmware asset. The asset name is defined at compile time
+via `OTA_FIRMWARE_ASSET` in `include/ota/ota_update.h`:
+
+| Board | Asset Name |
+|-------|-----------|
+| PCB E1001 | `firmware-e1001.bin` |
+| PCB EE04 | `firmware-ee04.bin` |
+| ESP32-C3 | `firmware-c3.bin` |
 
 ## Version Comparison
 


### PR DESCRIPTION
Updates documentation for recent changes:
- OTA docs now show board-specific firmware assets
- GitHub Actions docs reflect multi-board matrix builds
- Weather API docs note UV index is Auto-mode only