### PR TITLE
feat: trip mode configuration (UI + NVS storage) (#283)

### DIFF
--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -931,6 +931,13 @@
           return;
       }
 
+      // Validate destination when trip mode is active
+      var tripModeActive = document.getElementById('trip-mode-on').classList.contains('active');
+      if (tripModeActive && !document.getElementById('trip-dest-id').value.trim()) {
+          alert('Bitte wählen Sie eine Ziel-Haltestelle für den Verbindungsmodus aus.');
+          return;
+      }
+
       // Validate "city-lat" and "city-lon" for display modes 0 and 1
       if ((displayMode === '0' || displayMode === '1') && (cityLat.trim() === '' || cityLon.trim() === '')) {
           alert('Bitte geben Sie gültige Breitengrad- und Längengradwerte ein, um den Anzeigemodus zu speichern.');

--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -336,6 +336,25 @@
 
     <div class="config-item">
       <div class="label">
+        Anzeigemodus ÖPNV
+        <span class="tooltip">ℹ️
+          <span class="tooltiptext">Abfahrten: zeigt nächste Abfahrten ab Ihrer Haltestelle. Verbindungen: zeigt Reiseverbindungen zu einem Ziel.</span>
+        </span>
+      </div>
+      <div class="config-row" style="display:flex; gap:0.5em;">
+        <button type="button" id="trip-mode-off" class="chip active" onclick="setTripMode(false)">Abfahrten</button>
+        <button type="button" id="trip-mode-on" class="chip" onclick="setTripMode(true)">Verbindungen</button>
+      </div>
+      <div id="trip-dest-section" style="display:none; margin-top:0.5em;">
+        <div class="label">Ziel-Haltestelle</div>
+        <input type="text" id="trip-dest-input" style="width:100%; padding:0.5em; font-size:1em; border:1px solid #ccc; border-radius:5px;" placeholder="Ziel eingeben..." autocomplete="off">
+        <div id="trip-dest-suggestions" style="display:none; position:relative; background:#fff; border:1px solid #ccc; border-radius:5px; max-height:200px; overflow-y:auto;"></div>
+        <input type="hidden" id="trip-dest-id" value="{{TRIP_DEST_ID}}">
+      </div>
+    </div>
+
+    <div class="config-item">
+      <div class="label">
         Verkehrsmittel-Filter
         <span class="tooltip">ℹ️
           <span class="tooltiptext">Wählen Sie die Verkehrsmittel aus, die Sie nutzen möchten.</span>
@@ -641,6 +660,49 @@
       event.target.style.display = 'none';
     }
 
+    // --- Trip mode toggle ---
+    function setTripMode(enabled) {
+      document.getElementById('trip-mode-on').classList.toggle('active', enabled);
+      document.getElementById('trip-mode-off').classList.toggle('active', !enabled);
+      document.getElementById('trip-dest-section').style.display = enabled ? 'block' : 'none';
+    }
+    // Initialize trip mode from template
+    if ('{{TRIP_MODE}}' === '1') setTripMode(true);
+
+    // --- Trip destination autocomplete ---
+    (function() {
+      var input = document.getElementById('trip-dest-input');
+      var suggestions = document.getElementById('trip-dest-suggestions');
+      var hiddenId = document.getElementById('trip-dest-id');
+      if (hiddenId.value) input.value = hiddenId.value.replace(/.*@O=([^@]*)@.*/, '$1');
+
+      input.addEventListener('input', function() {
+        var q = input.value.trim();
+        if (q.length < 5) { suggestions.style.display = 'none'; return; }
+        fetch('/api/stop?q=' + encodeURIComponent(q))
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            suggestions.innerHTML = '';
+            data.forEach(function(stop) {
+              var div = document.createElement('div');
+              div.textContent = stop.name;
+              div.style.padding = '0.5em';
+              div.style.cursor = 'pointer';
+              div.style.borderBottom = '1px solid #eee';
+              div.onmouseover = function() { div.style.background = '#f0f8ff'; };
+              div.onmouseout = function() { div.style.background = '#fff'; };
+              div.onclick = function() {
+                input.value = stop.name;
+                hiddenId.value = stop.id;
+                suggestions.style.display = 'none';
+              };
+              suggestions.appendChild(div);
+            });
+            suggestions.style.display = data.length > 0 ? 'block' : 'none';
+          });
+      });
+    })();
+
     // --- Haltestelle bearbeiten ---
     function editStop() {
       document.getElementById('stop-select').style.display = 'none';
@@ -917,7 +979,9 @@
         weekendSleepStart: weekendSleepStart,
         weekendSleepEnd: weekendSleepEnd,
         otaEnabled: otaEnabled,
-        otaCheckTime: otaCheckTime
+        otaCheckTime: otaCheckTime,
+        tripMode: document.getElementById('trip-mode-on').classList.contains('active'),
+        tripDestId: document.getElementById('trip-dest-id').value
       };
 
       fetch('/save_config', {

--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -331,7 +331,7 @@
       </div>
       <div><a class="edit-link" onclick="editStop()">Andere Haltestelle eingeben</a></div>
       <div id="stop-suggestions" style="display:none;"></div>
-      <div class="help-text" id="stop-help" style="display:none;">Stadtname zuerst, dann Straße (z.B. "Frankfurt Kaiserstraße") eingeben und Vorschlag auswählen.</div>
+      <div class="help-text" id="stop-help">Stadtname zuerst, dann Straße (z.B. "Frankfurt Kaiserstraße") eingeben und Vorschlag auswählen.</div>
     </div>
 
     <div class="config-item">
@@ -349,6 +349,7 @@
         <div class="label">Ziel-Haltestelle</div>
         <input type="text" id="trip-dest-input" style="width:100%; padding:0.5em; font-size:1em; border:1px solid #ccc; border-radius:5px;" placeholder="Ziel eingeben..." autocomplete="off">
         <div id="trip-dest-suggestions" style="display:none; position:relative; background:#fff; border:1px solid #ccc; border-radius:5px; max-height:200px; overflow-y:auto;"></div>
+        <div class="help-text">Stadtname zuerst, dann Straße (z.B. "Frankfurt Kaiserstraße") eingeben und Vorschlag auswählen.</div>
         <input type="hidden" id="trip-dest-id" value="{{TRIP_DEST_ID}}">
       </div>
     </div>

--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -668,7 +668,8 @@
       document.getElementById('trip-dest-section').style.display = enabled ? 'block' : 'none';
     }
     // Initialize trip mode from template
-    if ('{{TRIP_MODE}}' === '1') setTripMode(true);
+    var savedTripMode = '{{TRIP_MODE}}';
+    if (savedTripMode === '1' || savedTripMode === 'true') setTripMode(true);
 
     // --- Trip destination autocomplete ---
     (function() {

--- a/include/config/config_manager.h
+++ b/include/config/config_manager.h
@@ -51,6 +51,10 @@ struct RTCConfigData {
     // Transport filters (simplified - store as bit flags)
     uint16_t filterFlags; // 2 byte
 
+    // Trip/connection mode
+    bool tripMode;              // false = departures, true = connections (A→B)
+    char tripDestId[128];       // Destination stop ID for trip mode
+
     // System state
     bool configMode; // 1 byte
     uint32_t lastUpdate; // 4 bytes (timestamp)

--- a/src/config/config_manager.cpp
+++ b/src/config/config_manager.cpp
@@ -34,6 +34,8 @@ RTC_DATA_ATTR RTCConfigData ConfigManager::rtcConfig = {
     "", // otaCheckTime - empty = will be randomized on first boot
     FILTER_R | FILTER_S | FILTER_U | FILTER_TRAM | FILTER_BUS | FILTER_HIGHFLOOR | FILTER_FERRY | FILTER_CALLBUS,
     // filterFlags - Default filters
+    false, // tripMode - default to departures (not connections)
+    "", // tripDestId - no destination
     true, // configMode
     0, // lastUpdate
     false, // inTemporaryMode - default to normal mode
@@ -175,6 +177,10 @@ bool ConfigManager::loadFromNVS(bool force = false) {
             FILTER_FERRY | FILTER_CALLBUS;
     }
 
+    // Load trip mode configuration
+    rtcConfig.tripMode = preferences.getBool("tripMode", false);
+    String tripDest = preferences.getString("tripDestId", "");
+    copyString(rtcConfig.tripDestId, tripDest, sizeof(rtcConfig.tripDestId));
 
     preferences.end();
 
@@ -239,6 +245,9 @@ bool ConfigManager::saveToNVS() {
         preferences.putString(key.c_str(), filters[i]);
     }
 
+    // Save trip mode configuration
+    preferences.putBool("tripMode", rtcConfig.tripMode);
+    preferences.putString("tripDestId", rtcConfig.tripDestId);
 
     preferences.end();
 
@@ -497,6 +506,9 @@ void ConfigManager::updateFromJson(const JsonDocument& doc) {
     if (!doc["otaEnabled"].isNull()) config.otaEnabled = doc["otaEnabled"].as<bool>();
     if (!doc["otaCheckTime"].isNull()) strncpy(config.otaCheckTime, doc["otaCheckTime"].as<const char*>(),
                                                  sizeof(config.otaCheckTime) - 1);
+    if (!doc["tripMode"].isNull()) config.tripMode = doc["tripMode"].as<bool>();
+    if (!doc["tripDestId"].isNull()) strncpy(config.tripDestId, doc["tripDestId"].as<const char*>(),
+                                               sizeof(config.tripDestId) - 1);
 
     if (!doc["filters"].isNull()) {
         std::vector<String> filterList;

--- a/src/config/config_page.cpp
+++ b/src/config/config_page.cpp
@@ -76,6 +76,8 @@ static String renderConfigPageHtml() {
             else if (varName == "WEEKEND_SLEEP_END") { page += config.weekendSleepEnd; }
             else if (varName == "OTA_ENABLED") { page += config.otaEnabled ? "true" : "false"; }
             else if (varName == "OTA_CHECK_TIME") { page += config.otaCheckTime; }
+            else if (varName == "TRIP_MODE") { page += config.tripMode ? "1" : "0"; }
+            else if (varName == "TRIP_DEST_ID") { page += config.tripDestId; }
             else if (varName == "SAVED_FILTERS") { page += filtersJs; }
             else if (varName == "LAT") { page += String(pageData.getLatitude(), 6); }
             else if (varName == "LON") { page += String(pageData.getLongitude(), 6); }

--- a/test/test_timing_manager/mocks/config_manager.cpp
+++ b/test/test_timing_manager/mocks/config_manager.cpp
@@ -32,10 +32,12 @@ RTCConfigData ConfigManager::rtcConfig = {
     (uint16_t)(
         FILTER_R | FILTER_S | FILTER_U | FILTER_TRAM | FILTER_BUS | FILTER_HIGHFLOOR | FILTER_FERRY | FILTER_CALLBUS),
     // filterFlags
+    false, // tripMode
+    "", // tripDestId
     false, // configMode
     0, // lastUpdate
     false, // inTemporaryMode
-    0xFF, // temporaryDisplayMode
+    (uint8_t)0xFF, // temporaryDisplayMode
     0 // temporaryModeActivationTime
 };
 


### PR DESCRIPTION
## Summary

Adds trip/connection mode configuration. Users can choose between showing departures from a stop or connections to a destination.

## Changes

- **Config struct**: `tripMode` (bool) + `tripDestId` (char[128])
- **NVS**: load/save for trip fields
- **JSON**: `updateFromJson` handles `tripMode` and `tripDestId`
- **UI**: Toggle 'Abfahrten' / 'Verbindungen' + destination stop autocomplete
- **Validation**: Blocks save if destination not selected in trip mode
- **Help text**: Same hint shown for both start and destination stop inputs
- **Template**: `{{TRIP_MODE}}` and `{{TRIP_DEST_ID}}` for pre-populating on reload

## Tests

- Build: SUCCESS
- Native tests: 42/42 pass

Closes #283