### PR TITLE
fix: trip display bug fixes

### DIFF
--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -600,9 +600,17 @@
                 opt.textContent = s.name + '   (' + s.dist + 'm)';
                 stopSelect.appendChild(opt);
               });
+              // Pre-select saved stop if it exists in the list
+              var savedStopId = '{{STOP_ID}}';
+              if (savedStopId) {
+                stopSelect.value = savedStopId;
+              }
             } else {
               stopSelect.innerHTML = '<option>Keine Haltestellen gefunden</option>';
             }
+            // Re-apply trip mode after DOM is fully loaded
+            var savedTripMode = '{{TRIP_MODE}}';
+            if (savedTripMode === '1' || savedTripMode === 'true') setTripMode(true);
           })
           .catch(function(err) {
             console.error('Init error:', err);

--- a/include/api/rmv_api.h
+++ b/include/api/rmv_api.h
@@ -41,6 +41,7 @@ struct TripLeg {
     char direction[48];      // "Heidelberg Bahnhof" (vehicle final destination)
     char arrivalStation[48]; // "Konstablerwache" (where you get off)
     char platform[6];        // "10"
+    bool cancelled;          // true if this leg is cancelled
 };
 
 struct TripConnection {

--- a/include/api/rmv_api.h
+++ b/include/api/rmv_api.h
@@ -38,7 +38,8 @@ struct TripLeg {
     char rtDepartureTime[6]; // "23:14" (real-time, empty if on-time)
     char rtArrivalTime[6];   // "23:33" (real-time, empty if on-time)
     char line[10];           // "RB68"
-    char direction[48];      // "Heidelberg Bahnhof"
+    char direction[48];      // "Heidelberg Bahnhof" (vehicle final destination)
+    char arrivalStation[48]; // "Konstablerwache" (where you get off)
     char platform[6];        // "10"
 };
 

--- a/src/api/rmv_api.cpp
+++ b/src/api/rmv_api.cpp
@@ -404,6 +404,7 @@ bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData
     filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["time"] = true;
     filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["rtTime"] = true;
     filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["name"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["cancelled"] = true;
 
     // Stream and parse
     Stream& rawStream = http.getStream();
@@ -458,6 +459,8 @@ bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData
             const char* track = leg["Origin"]["track"] | "";
             strncpy(tl.platform, track, sizeof(tl.platform) - 1);
             tl.platform[sizeof(tl.platform) - 1] = '\0';
+
+            tl.cancelled = leg["cancelled"] | false;
 
             conn.legCount++;
         }

--- a/src/api/rmv_api.cpp
+++ b/src/api/rmv_api.cpp
@@ -403,6 +403,7 @@ bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData
     filter["Trip"][0]["LegList"]["Leg"][0]["Origin"]["track"] = true;
     filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["time"] = true;
     filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["rtTime"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["name"] = true;
 
     // Stream and parse
     Stream& rawStream = http.getStream();
@@ -450,6 +451,9 @@ bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData
 
             strncpy(tl.direction, leg["direction"] | "", sizeof(tl.direction) - 1);
             tl.direction[sizeof(tl.direction) - 1] = '\0';
+
+            strncpy(tl.arrivalStation, leg["Destination"]["name"] | "", sizeof(tl.arrivalStation) - 1);
+            tl.arrivalStation[sizeof(tl.arrivalStation) - 1] = '\0';
 
             const char* track = leg["Origin"]["track"] | "";
             strncpy(tl.platform, track, sizeof(tl.platform) - 1);

--- a/src/config/config_page.cpp
+++ b/src/config/config_page.cpp
@@ -78,6 +78,7 @@ static String renderConfigPageHtml() {
             else if (varName == "OTA_CHECK_TIME") { page += config.otaCheckTime; }
             else if (varName == "TRIP_MODE") { page += config.tripMode ? "1" : "0"; }
             else if (varName == "TRIP_DEST_ID") { page += config.tripDestId; }
+            else if (varName == "STOP_ID") { page += config.selectedStopId; }
             else if (varName == "SAVED_FILTERS") { page += filtersJs; }
             else if (varName == "LAT") { page += String(pageData.getLatitude(), 6); }
             else if (varName == "LON") { page += String(pageData.getLongitude(), 6); }

--- a/src/display/trip_display.cpp
+++ b/src/display/trip_display.cpp
@@ -90,8 +90,18 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
     int16_t colArrTime = rightEdge - TextUtils::getTextWidth("23:06") - 5;
     int16_t colArrDelay = colArrTime + TextUtils::getTextWidth("23:06") + 3;
 
-    // Departure time
-    TextUtils::printTextAtTopMargin(colDepTime, row1Y, conn.legs[0].departureTime);
+    // Check if any leg is cancelled
+    bool hasCancelled = false;
+    for (int leg = 0; leg < conn.legCount; leg++) {
+        if (conn.legs[leg].cancelled) { hasCancelled = true; break; }
+    }
+
+    // Departure time (strikethrough if cancelled)
+    if (hasCancelled) {
+        TextUtils::printStrikethroughTextAtTopMargin(colDepTime, row1Y, conn.legs[0].departureTime);
+    } else {
+        TextUtils::printTextAtTopMargin(colDepTime, row1Y, conn.legs[0].departureTime);
+    }
 
     // Departure delay (more space from time)
     if (conn.legs[0].rtDepartureTime[0] != '\0' &&
@@ -123,7 +133,11 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
 
     // Arrival time (fixed position, right side of row 1)
     const TripLeg& lastLeg = conn.legs[conn.legCount - 1];
-    TextUtils::printTextAtTopMargin(colArrTime, row1Y, lastLeg.arrivalTime);
+    if (hasCancelled) {
+        TextUtils::printStrikethroughTextAtTopMargin(colArrTime, row1Y, lastLeg.arrivalTime);
+    } else {
+        TextUtils::printTextAtTopMargin(colArrTime, row1Y, lastLeg.arrivalTime);
+    }
 
     // Arrival delay
     if (lastLeg.rtArrivalTime[0] != '\0' &&
@@ -158,10 +172,16 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
     TextUtils::printTextAtTopMargin(leftX, row2Y, inStr.c_str());
     int16_t transferColX = leftX + COL_LINES; // Align with line boxes above
 
-    // Duration (right-aligned on row 2)
-    String durStr = String(conn.durationMinutes) + " min";
-    int16_t durW = TextUtils::getTextWidth(durStr);
-    TextUtils::printTextAtTopMargin(rightEdge - durW, row2Y, durStr.c_str());
+    // Duration (right-aligned on row 2) or "Fällt aus" if cancelled
+    if (hasCancelled) {
+        String cancelStr = "Fällt aus";
+        int16_t cancelW = TextUtils::getTextWidth(cancelStr);
+        TextUtils::printTextAtTopMargin(rightEdge - cancelW, row2Y, cancelStr.c_str());
+    } else {
+        String durStr = String(conn.durationMinutes) + " min";
+        int16_t durW = TextUtils::getTextWidth(durStr);
+        TextUtils::printTextAtTopMargin(rightEdge - durW, row2Y, durStr.c_str());
+    }
 
     // Transfer 1 (if exists)
     if (conn.legCount > 1) {

--- a/src/display/trip_display.cpp
+++ b/src/display/trip_display.cpp
@@ -83,11 +83,18 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
     // === ROW 1: dep_time [+delay]  [line1] -O- [line2]  arr_time [+delay]  duration ===
     int16_t row1Y = y + 10;
 
-    // Departure time
-    TextUtils::printTextAtTopMargin(leftX, row1Y, conn.legs[0].departureTime);
+    // Fixed column positions for vertical alignment across all connections
+    int16_t colDepTime = leftX;
+    int16_t colDelay = leftX + 38;  // gap after "23:06"
+    int16_t colLines = leftX + COL_LINES;
+    int16_t colDuration = rightEdge - TextUtils::getTextWidth("999 min");
+    int16_t colArrTime = colDuration - TextUtils::getTextWidth("23:06") - 12;
+    int16_t colArrDelay = colArrTime + TextUtils::getTextWidth("23:06") + 3;
 
-    // Departure delay
-    int16_t currentX = leftX + 35;
+    // Departure time
+    TextUtils::printTextAtTopMargin(colDepTime, row1Y, conn.legs[0].departureTime);
+
+    // Departure delay (more space from time)
     if (conn.legs[0].rtDepartureTime[0] != '\0' &&
         strcmp(conn.legs[0].rtDepartureTime, conn.legs[0].departureTime) != 0) {
         int schedMin = atoi(conn.legs[0].departureTime) * 60 + atoi(conn.legs[0].departureTime + 3);
@@ -95,12 +102,12 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
         int delay = rtMin - schedMin;
         if (delay > 0) {
             String delayStr = "+" + String(delay);
-            TextUtils::printTextAtTopMargin(currentX, row1Y, delayStr.c_str());
+            TextUtils::printTextAtTopMargin(colDelay, row1Y, delayStr.c_str());
         }
     }
 
     // Line boxes with -O- transfer symbols
-    currentX = leftX + COL_LINES;
+    int16_t currentX = colLines;
     for (int leg = 0; leg < conn.legCount; leg++) {
         if (leg > 0) {
             TextUtils::printTextAtTopMargin(currentX, row1Y, "-O-");
@@ -109,23 +116,19 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
         String line = String(conn.legs[leg].line);
         int16_t lineW = TextUtils::getTextWidth(line) + 6;
         // Don't overflow into arrival area
-        if (currentX + lineW > rightEdge - 90) break;
+        if (currentX + lineW > colArrTime - 5) break;
         display.drawRect(currentX, row1Y - 1, lineW, ROW_HEIGHT - 4, GxEPD_BLACK);
         TextUtils::printTextAtTopMargin(currentX + 3, row1Y, line.c_str());
         currentX += lineW + 4;
     }
 
-    // Duration (far right)
+    // Duration (fixed position, far right)
     String durStr = String(conn.durationMinutes) + " min";
-    int16_t durW = TextUtils::getTextWidth(durStr);
-    TextUtils::printTextAtTopMargin(rightEdge - durW, row1Y, durStr.c_str());
+    TextUtils::printTextAtTopMargin(colDuration, row1Y, durStr.c_str());
 
-    // Arrival time
+    // Arrival time (fixed position)
     const TripLeg& lastLeg = conn.legs[conn.legCount - 1];
-    String arrStr = String(lastLeg.arrivalTime);
-    int16_t arrW = TextUtils::getTextWidth(arrStr);
-    int16_t arrX = rightEdge - durW - arrW - 10;
-    TextUtils::printTextAtTopMargin(arrX, row1Y, arrStr.c_str());
+    TextUtils::printTextAtTopMargin(colArrTime, row1Y, lastLeg.arrivalTime);
 
     // Arrival delay
     if (lastLeg.rtArrivalTime[0] != '\0' &&
@@ -135,7 +138,7 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
         int delay = rtMin - schedMin;
         if (delay > 0) {
             String delayStr = "+" + String(delay);
-            TextUtils::printTextAtTopMargin(arrX + arrW + 2, row1Y, delayStr.c_str());
+            TextUtils::printTextAtTopMargin(colArrDelay, row1Y, delayStr.c_str());
         }
     }
 
@@ -156,8 +159,9 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
     if (minutesUntil < 0) minutesUntil += 24 * 60;
 
     String inStr = "in " + String(minutesUntil) + " min";
+    inStr = TextUtils::shortenTextToFit(inStr, COL_LINES - 5);
     TextUtils::printTextAtTopMargin(leftX, row2Y, inStr.c_str());
-    int16_t transferColX = leftX + max((int16_t)COL_LINES, (int16_t)(TextUtils::getTextWidth(inStr) + 10));
+    int16_t transferColX = leftX + COL_LINES; // Align with line boxes above
 
     // Transfer 1 (if exists)
     if (conn.legCount > 1) {

--- a/src/display/trip_display.cpp
+++ b/src/display/trip_display.cpp
@@ -87,8 +87,7 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
     int16_t colDepTime = leftX;
     int16_t colDelay = leftX + 38;  // gap after "23:06"
     int16_t colLines = leftX + COL_LINES;
-    int16_t colDuration = rightEdge - TextUtils::getTextWidth("999 min");
-    int16_t colArrTime = colDuration - TextUtils::getTextWidth("23:06") - 12;
+    int16_t colArrTime = rightEdge - TextUtils::getTextWidth("23:06") - 5;
     int16_t colArrDelay = colArrTime + TextUtils::getTextWidth("23:06") + 3;
 
     // Departure time
@@ -115,18 +114,14 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
         }
         String line = String(conn.legs[leg].line);
         int16_t lineW = TextUtils::getTextWidth(line) + 6;
-        // Don't overflow into arrival area
+        // Don't overflow into arrival time area
         if (currentX + lineW > colArrTime - 5) break;
         display.drawRect(currentX, row1Y - 1, lineW, ROW_HEIGHT - 4, GxEPD_BLACK);
         TextUtils::printTextAtTopMargin(currentX + 3, row1Y, line.c_str());
         currentX += lineW + 4;
     }
 
-    // Duration (fixed position, far right)
-    String durStr = String(conn.durationMinutes) + " min";
-    TextUtils::printTextAtTopMargin(colDuration, row1Y, durStr.c_str());
-
-    // Arrival time (fixed position)
+    // Arrival time (fixed position, right side of row 1)
     const TripLeg& lastLeg = conn.legs[conn.legCount - 1];
     TextUtils::printTextAtTopMargin(colArrTime, row1Y, lastLeg.arrivalTime);
 
@@ -162,6 +157,11 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
     inStr = TextUtils::shortenTextToFit(inStr, COL_LINES - 5);
     TextUtils::printTextAtTopMargin(leftX, row2Y, inStr.c_str());
     int16_t transferColX = leftX + COL_LINES; // Align with line boxes above
+
+    // Duration (right-aligned on row 2)
+    String durStr = String(conn.durationMinutes) + " min";
+    int16_t durW = TextUtils::getTextWidth(durStr);
+    TextUtils::printTextAtTopMargin(rightEdge - durW, row2Y, durStr.c_str());
 
     // Transfer 1 (if exists)
     if (conn.legCount > 1) {

--- a/src/display/trip_display.cpp
+++ b/src/display/trip_display.cpp
@@ -154,34 +154,31 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
     // === ROW 2: "in X min" + Transfer 1 ===
     int16_t row2Y = row1Y + ROW_HEIGHT;
 
-    // "in X min"
-    int depHour = atoi(conn.legs[0].departureTime);
-    int depMin = atoi(conn.legs[0].departureTime + 3);
-    if (conn.legs[0].rtDepartureTime[0] != '\0') {
-        depHour = atoi(conn.legs[0].rtDepartureTime);
-        depMin = atoi(conn.legs[0].rtDepartureTime + 3);
+    String inStr;
+    if (hasCancelled) {
+        inStr = "Fällt aus";
+    } else {
+        int depHour = atoi(conn.legs[0].departureTime);
+        int depMin = atoi(conn.legs[0].departureTime + 3);
+        if (conn.legs[0].rtDepartureTime[0] != '\0') {
+            depHour = atoi(conn.legs[0].rtDepartureTime);
+            depMin = atoi(conn.legs[0].rtDepartureTime + 3);
+        }
+        struct tm* nowTm = localtime((time_t*)&currentTime);
+        int nowMinutes = nowTm->tm_hour * 60 + nowTm->tm_min;
+        int depMinutes = depHour * 60 + depMin;
+        int minutesUntil = depMinutes - nowMinutes;
+        if (minutesUntil < 0) minutesUntil += 24 * 60;
+        inStr = "in " + String(minutesUntil) + " min";
     }
-    struct tm* nowTm = localtime((time_t*)&currentTime);
-    int nowMinutes = nowTm->tm_hour * 60 + nowTm->tm_min;
-    int depMinutes = depHour * 60 + depMin;
-    int minutesUntil = depMinutes - nowMinutes;
-    if (minutesUntil < 0) minutesUntil += 24 * 60;
-
-    String inStr = "in " + String(minutesUntil) + " min";
     inStr = TextUtils::shortenTextToFit(inStr, COL_LINES - 5);
     TextUtils::printTextAtTopMargin(leftX, row2Y, inStr.c_str());
     int16_t transferColX = leftX + COL_LINES; // Align with line boxes above
 
-    // Duration (right-aligned on row 2) or "Fällt aus" if cancelled
-    if (hasCancelled) {
-        String cancelStr = "Fällt aus";
-        int16_t cancelW = TextUtils::getTextWidth(cancelStr);
-        TextUtils::printTextAtTopMargin(rightEdge - cancelW, row2Y, cancelStr.c_str());
-    } else {
-        String durStr = String(conn.durationMinutes) + " min";
-        int16_t durW = TextUtils::getTextWidth(durStr);
-        TextUtils::printTextAtTopMargin(rightEdge - durW, row2Y, durStr.c_str());
-    }
+    // Duration (right-aligned on row 2, always shown)
+    String durStr = String(conn.durationMinutes) + " min";
+    int16_t durW = TextUtils::getTextWidth(durStr);
+    TextUtils::printTextAtTopMargin(rightEdge - durW, row2Y, durStr.c_str());
 
     // Transfer 1 (if exists)
     if (conn.legCount > 1) {

--- a/src/display/trip_display.cpp
+++ b/src/display/trip_display.cpp
@@ -157,6 +157,7 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
 
     String inStr = "in " + String(minutesUntil) + " min";
     TextUtils::printTextAtTopMargin(leftX, row2Y, inStr.c_str());
+    int16_t transferColX = leftX + max((int16_t)COL_LINES, (int16_t)(TextUtils::getTextWidth(inStr) + 10));
 
     // Transfer 1 (if exists)
     if (conn.legCount > 1) {
@@ -167,9 +168,9 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
 
         String station = Util::shortenDestination(originFull, String(conn.legs[0].arrivalStation));
         String transferStr = "Umst: " + station + " (" + String(transferTime) + " min)";
-        int16_t maxTransferW = w - COL_LINES - MARGIN;
+        int16_t maxTransferW = (x + w) - transferColX - MARGIN;
         transferStr = TextUtils::shortenTextToFit(transferStr, maxTransferW);
-        TextUtils::printTextAtTopMargin(leftX + COL_LINES, row2Y, transferStr.c_str());
+        TextUtils::printTextAtTopMargin(transferColX, row2Y, transferStr.c_str());
     }
 
     // === ROW 3: Transfer 2+ (combined on one line if multiple) ===
@@ -189,9 +190,9 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
             combined += station + " (" + String(transferTime) + " min)";
         }
         String transferStr = "Umst: " + combined;
-        int16_t maxTransferW = w - COL_LINES - MARGIN;
+        int16_t maxTransferW = (x + w) - transferColX - MARGIN;
         transferStr = TextUtils::shortenTextToFit(transferStr, maxTransferW);
-        TextUtils::printTextAtTopMargin(leftX + COL_LINES, row3Y, transferStr.c_str());
+        TextUtils::printTextAtTopMargin(transferColX, row3Y, transferStr.c_str());
     }
 
     return CONNECTION_HEIGHT;

--- a/src/display/trip_display.cpp
+++ b/src/display/trip_display.cpp
@@ -165,7 +165,7 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
         int transferTime = nextDepMin - arrMin;
         if (transferTime < 0) transferTime += 24 * 60;
 
-        String station = Util::shortenDestination(originFull, String(conn.legs[0].direction));
+        String station = Util::shortenDestination(originFull, String(conn.legs[0].arrivalStation));
         String transferStr = "Umst: " + station + " (" + String(transferTime) + " min)";
         int16_t maxTransferW = w - COL_LINES - MARGIN;
         transferStr = TextUtils::shortenTextToFit(transferStr, maxTransferW);
@@ -184,7 +184,7 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
             int transferTime = nextDepMin - arrMin;
             if (transferTime < 0) transferTime += 24 * 60;
 
-            String station = Util::shortenDestination(originFull, String(conn.legs[leg].direction));
+            String station = Util::shortenDestination(originFull, String(conn.legs[leg].arrivalStation));
             if (combined.length() > 0) combined += ", ";
             combined += station + " (" + String(transferTime) + " min)";
         }

--- a/src/util/device_mode_manager.cpp
+++ b/src/util/device_mode_manager.cpp
@@ -104,7 +104,8 @@ void DeviceModeManager::showWeatherDeparture() {
 
     if (config.tripMode) {
         // Trip/connection mode
-        TripData trip;
+        static TripData trip; // static: ~4KB too large for stack
+        memset(&trip, 0, sizeof(trip));
         getTripFromRMV(config.selectedStopId, config.tripDestId, trip);
         TimingManager::markTransportUpdated();
         shutdownWiFiBeforeRender();


### PR DESCRIPTION
Collection of bug fixes for the trip connections feature:

- **Transfer station name**: Show actual transfer station (Destination.name) instead of vehicle direction
- **Stack overflow**: TripData moved to static (4.4KB too large for stack)
- **Column alignment**: Fixed vertical alignment across all connections
- **Duration moved to row 2**: More horizontal space for 4-leg connections
- **Spacing**: Use full 480px height (75px per connection)
- **City qualifier stripped** from transfer station names
- **3-digit minutes**: Dynamic spacing between 'in X min' and 'Umst:'
- **Cancelled legs**: Strikethrough times, 'Fällt aus' in place of countdown
- **Config reload**: Pre-select saved stop + trip mode after AJAX