### PR TITLE
feat: trip connections mode (epic)

### DIFF
--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -331,7 +331,27 @@
       </div>
       <div><a class="edit-link" onclick="editStop()">Andere Haltestelle eingeben</a></div>
       <div id="stop-suggestions" style="display:none;"></div>
-      <div class="help-text" id="stop-help" style="display:none;">Stadtname zuerst, dann Straße (z.B. "Frankfurt Kaiserstraße") eingeben und Vorschlag auswählen.</div>
+      <div class="help-text" id="stop-help">Stadtname zuerst, dann Straße (z.B. "Frankfurt Kaiserstraße") eingeben und Vorschlag auswählen.</div>
+    </div>
+
+    <div class="config-item">
+      <div class="label">
+        Anzeigemodus ÖPNV
+        <span class="tooltip">ℹ️
+          <span class="tooltiptext">Abfahrten: zeigt nächste Abfahrten ab Ihrer Haltestelle. Verbindungen: zeigt Reiseverbindungen zu einem Ziel.</span>
+        </span>
+      </div>
+      <div class="config-row" style="display:flex; gap:0.5em;">
+        <button type="button" id="trip-mode-off" class="chip active" onclick="setTripMode(false)">Abfahrten</button>
+        <button type="button" id="trip-mode-on" class="chip" onclick="setTripMode(true)">Verbindungen</button>
+      </div>
+      <div id="trip-dest-section" style="display:none; margin-top:0.5em;">
+        <div class="label">Ziel-Haltestelle</div>
+        <input type="text" id="trip-dest-input" style="width:100%; padding:0.5em; font-size:1em; border:1px solid #ccc; border-radius:5px;" placeholder="Ziel eingeben..." autocomplete="off">
+        <div id="trip-dest-suggestions" style="display:none; position:relative; background:#fff; border:1px solid #ccc; border-radius:5px; max-height:200px; overflow-y:auto;"></div>
+        <div class="help-text">Stadtname zuerst, dann Straße (z.B. "Frankfurt Kaiserstraße") eingeben und Vorschlag auswählen.</div>
+        <input type="hidden" id="trip-dest-id" value="{{TRIP_DEST_ID}}">
+      </div>
     </div>
 
     <div class="config-item">
@@ -641,6 +661,50 @@
       event.target.style.display = 'none';
     }
 
+    // --- Trip mode toggle ---
+    function setTripMode(enabled) {
+      document.getElementById('trip-mode-on').classList.toggle('active', enabled);
+      document.getElementById('trip-mode-off').classList.toggle('active', !enabled);
+      document.getElementById('trip-dest-section').style.display = enabled ? 'block' : 'none';
+    }
+    // Initialize trip mode from template
+    var savedTripMode = '{{TRIP_MODE}}';
+    if (savedTripMode === '1' || savedTripMode === 'true') setTripMode(true);
+
+    // --- Trip destination autocomplete ---
+    (function() {
+      var input = document.getElementById('trip-dest-input');
+      var suggestions = document.getElementById('trip-dest-suggestions');
+      var hiddenId = document.getElementById('trip-dest-id');
+      if (hiddenId.value) input.value = hiddenId.value.replace(/.*@O=([^@]*)@.*/, '$1');
+
+      input.addEventListener('input', function() {
+        var q = input.value.trim();
+        if (q.length < 5) { suggestions.style.display = 'none'; return; }
+        fetch('/api/stop?q=' + encodeURIComponent(q))
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            suggestions.innerHTML = '';
+            data.forEach(function(stop) {
+              var div = document.createElement('div');
+              div.textContent = stop.name;
+              div.style.padding = '0.5em';
+              div.style.cursor = 'pointer';
+              div.style.borderBottom = '1px solid #eee';
+              div.onmouseover = function() { div.style.background = '#f0f8ff'; };
+              div.onmouseout = function() { div.style.background = '#fff'; };
+              div.onclick = function() {
+                input.value = stop.name;
+                hiddenId.value = stop.id;
+                suggestions.style.display = 'none';
+              };
+              suggestions.appendChild(div);
+            });
+            suggestions.style.display = data.length > 0 ? 'block' : 'none';
+          });
+      });
+    })();
+
     // --- Haltestelle bearbeiten ---
     function editStop() {
       document.getElementById('stop-select').style.display = 'none';
@@ -868,6 +932,13 @@
           return;
       }
 
+      // Validate destination when trip mode is active
+      var tripModeActive = document.getElementById('trip-mode-on').classList.contains('active');
+      if (tripModeActive && !document.getElementById('trip-dest-id').value.trim()) {
+          alert('Bitte wählen Sie eine Ziel-Haltestelle für den Verbindungsmodus aus.');
+          return;
+      }
+
       // Validate "city-lat" and "city-lon" for display modes 0 and 1
       if ((displayMode === '0' || displayMode === '1') && (cityLat.trim() === '' || cityLon.trim() === '')) {
           alert('Bitte geben Sie gültige Breitengrad- und Längengradwerte ein, um den Anzeigemodus zu speichern.');
@@ -917,7 +988,9 @@
         weekendSleepStart: weekendSleepStart,
         weekendSleepEnd: weekendSleepEnd,
         otaEnabled: otaEnabled,
-        otaCheckTime: otaCheckTime
+        otaCheckTime: otaCheckTime,
+        tripMode: document.getElementById('trip-mode-on').classList.contains('active'),
+        tripDestId: document.getElementById('trip-dest-id').value
       };
 
       fetch('/save_config', {

--- a/data/config_my_station.html
+++ b/data/config_my_station.html
@@ -600,9 +600,17 @@
                 opt.textContent = s.name + '   (' + s.dist + 'm)';
                 stopSelect.appendChild(opt);
               });
+              // Pre-select saved stop if it exists in the list
+              var savedStopId = '{{STOP_ID}}';
+              if (savedStopId) {
+                stopSelect.value = savedStopId;
+              }
             } else {
               stopSelect.innerHTML = '<option>Keine Haltestellen gefunden</option>';
             }
+            // Re-apply trip mode after DOM is fully loaded
+            var savedTripMode = '{{TRIP_MODE}}';
+            if (savedTripMode === '1' || savedTripMode === 'true') setTripMode(true);
           })
           .catch(function(err) {
             console.error('Init error:', err);

--- a/docs/developer-guide/boot-process.md
+++ b/docs/developer-guide/boot-process.md
@@ -46,6 +46,8 @@ but can skip phases or branch based on conditions.
 - If Phase 2 (app setup needed): start configuration web server, transition to ON_LOOP
 - Check for OTA update (if scheduled time matches)
 - Fetch data from APIs (Phase 3: Complete)
+  - If `tripMode == true`: fetch trip connections via `/hapi/trip` (origin → destination)
+  - If `tripMode == false`: fetch departures via `/hapi/departureBoard` (single stop)
 - Disconnect WiFi (saves ~100mA during display rendering)
 - Render display
 

--- a/docs/reference/configuration-keys-quick-reference.md
+++ b/docs/reference/configuration-keys-quick-reference.md
@@ -35,6 +35,9 @@ For developers who need to quickly find the right key name for a specific layer:
 | **OTA** |
 | OTA Enabled | `ota-enabled` | `otaEnabled` | `otaEnabled` | `otaEnabled` |
 | OTA Check Time | `ota-check-time` | `otaCheckTime` | `otaCheckTime` | `otaCheckTime` |
+| **Trip/Connection Mode** |
+| Trip Mode | `trip-mode-on` | `tripMode` | `tripMode` | `tripMode` |
+| Trip Destination ID | `trip-dest-id` | `tripDestId` | `tripDestId` | `tripDestId` |
 | **System** |
 | Config Version | — | — | `cfgVersion` | — |
 

--- a/include/api/rmv_api.h
+++ b/include/api/rmv_api.h
@@ -31,6 +31,29 @@ struct DepartureData {
 
 extern std::vector<Station> stations;
 
+// === Trip/Connection data structures ===
+struct TripLeg {
+    char departureTime[6];   // "23:06"
+    char arrivalTime[6];     // "23:25"
+    char rtDepartureTime[6]; // "23:14" (real-time, empty if on-time)
+    char rtArrivalTime[6];   // "23:33" (real-time, empty if on-time)
+    char line[10];           // "RB68"
+    char direction[48];      // "Heidelberg Bahnhof"
+    char platform[6];        // "10"
+};
+
+struct TripConnection {
+    TripLeg legs[4];         // Max 4 legs (3 transfers)
+    int legCount;
+    int durationMinutes;     // Total journey time
+};
+
+struct TripData {
+    TripConnection connections[8]; // Next 8 connections
+    int connectionCount;
+};
+
 void getNearbyStops(float lat, float lon);
 bool getDepartureFromRMV(const char* stopId, DepartureData& departData);
+bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData);
 bool populateDepartureData(const JsonDocument& doc, DepartureData& departData);

--- a/include/api/rmv_api.h
+++ b/include/api/rmv_api.h
@@ -49,7 +49,7 @@ struct TripConnection {
 };
 
 struct TripData {
-    TripConnection connections[8]; // Next 8 connections
+    TripConnection connections[6]; // Max 6 (API limit for /hapi/trip)
     int connectionCount;
 };
 

--- a/include/api/rmv_api.h
+++ b/include/api/rmv_api.h
@@ -38,8 +38,10 @@ struct TripLeg {
     char rtDepartureTime[6]; // "23:14" (real-time, empty if on-time)
     char rtArrivalTime[6];   // "23:33" (real-time, empty if on-time)
     char line[10];           // "RB68"
-    char direction[48];      // "Heidelberg Bahnhof"
+    char direction[48];      // "Heidelberg Bahnhof" (vehicle final destination)
+    char arrivalStation[48]; // "Konstablerwache" (where you get off)
     char platform[6];        // "10"
+    bool cancelled;          // true if this leg is cancelled
 };
 
 struct TripConnection {

--- a/include/config/config_manager.h
+++ b/include/config/config_manager.h
@@ -51,6 +51,10 @@ struct RTCConfigData {
     // Transport filters (simplified - store as bit flags)
     uint16_t filterFlags; // 2 byte
 
+    // Trip/connection mode
+    bool tripMode;              // false = departures, true = connections (A→B)
+    char tripDestId[128];       // Destination stop ID for trip mode
+
     // System state
     bool configMode; // 1 byte
     uint32_t lastUpdate; // 4 bytes (timestamp)

--- a/include/display/display_manager.h
+++ b/include/display/display_manager.h
@@ -22,6 +22,7 @@ enum class UpdateRegion {
 class DisplayManager {
 public:
     static void displayHalfNHalf(const WeatherInfo& weather, const DepartureData& departures);
+    static void displayHalfNHalfTrip(const WeatherInfo& weather, const TripData& tripData);
     static void displayWeatherFull(const WeatherInfo& weather);
     static void displayDeparturesFull(const DepartureData& departures);
 

--- a/include/display/trip_display.h
+++ b/include/display/trip_display.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "api/rmv_api.h"
+#include <Arduino.h>
+
+class TripDisplay {
+public:
+    // Draw trip connections in the given area
+    static void drawTripConnections(const TripData& tripData, int16_t x, int16_t y, int16_t w, int16_t h);
+
+private:
+    // Draw a single connection, returns height consumed (0 if didn't fit)
+    static int16_t drawSingleConnection(const TripConnection& conn, int16_t x, int16_t y, int16_t w,
+                                        int16_t maxH, uint32_t currentTime);
+
+    // Calculate height needed for a connection
+    static int16_t getConnectionHeight(const TripConnection& conn);
+
+    // Extract station name from stop ID format "A=1@O=Name@X=...@Y=...@"
+    static String extractStopName(const char* stopId);
+};

--- a/src/api/rmv_api.cpp
+++ b/src/api/rmv_api.cpp
@@ -372,7 +372,7 @@ bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData
 
     char url[512];
     snprintf(url, sizeof(url),
-        "https://www.rmv.de/hapi/trip?accessId=%s&originId=%s&destId=%s&format=json&numF=8&products=%d&time=%s",
+        "https://www.rmv.de/hapi/trip?accessId=%s&originId=%s&destId=%s&format=json&numF=6&products=%d&time=%s",
         decrypted.c_str(), encodedOrigin.c_str(), encodedDest.c_str(),
         config.filterFlags, departureTime);
 
@@ -424,7 +424,7 @@ bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData
     // Parse trips
     JsonArray trips = doc["Trip"];
     for (JsonObject trip : trips) {
-        if (tripData.connectionCount >= 8) break;
+        if (tripData.connectionCount >= 6) break;
 
         TripConnection& conn = tripData.connections[tripData.connectionCount];
         conn.legCount = 0;

--- a/src/api/rmv_api.cpp
+++ b/src/api/rmv_api.cpp
@@ -326,3 +326,149 @@ bool getDepartureFromRMV(const char* stopId, DepartureData& departData) {
 
     return true;
 }
+
+
+// ============================================================================
+// Trip/Connection API
+// ============================================================================
+
+static int parseDuration(const char* dur) {
+    // Parse ISO 8601 duration: "PT19M" → 19, "PT1H19M" → 79
+    int h = 0, m = 0;
+    if (sscanf(dur, "PT%dH%dM", &h, &m) == 2) return h * 60 + m;
+    if (sscanf(dur, "PT%dM", &m) == 1) return m;
+    if (sscanf(dur, "PT%dH", &h) == 1) return h * 60;
+    return 0;
+}
+
+static void copyTime(char* dest, const char* src, size_t destSize) {
+    // Copy "HH:MM:SS" → "HH:MM" (first 5 chars)
+    if (src && strlen(src) >= 5) {
+        strncpy(dest, src, 5);
+        dest[5] = '\0';
+    } else {
+        dest[0] = '\0';
+    }
+}
+
+bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData) {
+    ESP_LOGI(TAG, "Fetching trip data: %s → %s", originId, destId);
+
+    tripData.connectionCount = 0;
+
+    RTCConfigData& config = ConfigManager::getConfig();
+    std::string decrypted = AESCrypto::getRMVAPIKey();
+
+    // Calculate departure time with walking time offset
+    time_t now;
+    time(&now);
+    now += config.walkingTime * 60; // Add walking time
+    struct tm* t = localtime(&now);
+    char departureTime[6];
+    snprintf(departureTime, sizeof(departureTime), "%02d:%02d", t->tm_hour, t->tm_min);
+
+    String encodedOrigin = Util::urlEncode(String(originId));
+    String encodedDest = Util::urlEncode(String(destId));
+
+    char url[512];
+    snprintf(url, sizeof(url),
+        "https://www.rmv.de/hapi/trip?accessId=%s&originId=%s&destId=%s&format=json&numF=8&products=%d&time=%s",
+        decrypted.c_str(), encodedOrigin.c_str(), encodedDest.c_str(),
+        config.filterFlags, departureTime);
+
+    ESP_LOGI(TAG, "Trip API request (time=%s, products=%d)", departureTime, config.filterFlags);
+
+    HTTPClient http;
+    http.begin(url);
+    http.setTimeout(10000);
+
+    const char* keys[] = {"Transfer-Encoding"};
+    http.collectHeaders(keys, 1);
+
+    int httpCode = http.GET();
+    if (httpCode != HTTP_CODE_OK) {
+        ESP_LOGE(TAG, "Trip HTTP GET failed: %s", http.errorToString(httpCode).c_str());
+        http.end();
+        return false;
+    }
+
+    // JSON filter — only parse the fields we need
+    JsonDocument filter;
+    filter["Trip"][0]["duration"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["type"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["name"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["direction"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["Origin"]["time"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["Origin"]["rtTime"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["Origin"]["track"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["time"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["rtTime"] = true;
+
+    // Stream and parse
+    Stream& rawStream = http.getStream();
+    ChunkDecodingStream decodedStream(http.getStream());
+    Stream& response = http.header("Transfer-Encoding") == "chunked" ? decodedStream : rawStream;
+
+    JsonDocument doc;
+    DeserializationError error = deserializeJson(doc, response,
+        DeserializationOption::Filter(filter),
+        DeserializationOption::NestingLimit(20));
+
+    http.end();
+
+    if (error) {
+        ESP_LOGE(TAG, "Trip JSON parse failed: %s", error.c_str());
+        return false;
+    }
+
+    // Parse trips
+    JsonArray trips = doc["Trip"];
+    for (JsonObject trip : trips) {
+        if (tripData.connectionCount >= 8) break;
+
+        TripConnection& conn = tripData.connections[tripData.connectionCount];
+        conn.legCount = 0;
+        conn.durationMinutes = parseDuration(trip["duration"] | "PT0M");
+
+        JsonArray legs = trip["LegList"]["Leg"];
+        for (JsonObject leg : legs) {
+            if (conn.legCount >= 4) break;
+
+            // Skip walking legs
+            const char* type = leg["type"] | "";
+            if (strcmp(type, "JNY") != 0) continue;
+
+            TripLeg& tl = conn.legs[conn.legCount];
+
+            copyTime(tl.departureTime, leg["Origin"]["time"] | "", sizeof(tl.departureTime));
+            copyTime(tl.arrivalTime, leg["Destination"]["time"] | "", sizeof(tl.arrivalTime));
+            copyTime(tl.rtDepartureTime, leg["Origin"]["rtTime"] | "", sizeof(tl.rtDepartureTime));
+            copyTime(tl.rtArrivalTime, leg["Destination"]["rtTime"] | "", sizeof(tl.rtArrivalTime));
+
+            strncpy(tl.line, leg["name"] | "", sizeof(tl.line) - 1);
+            tl.line[sizeof(tl.line) - 1] = '\0';
+
+            strncpy(tl.direction, leg["direction"] | "", sizeof(tl.direction) - 1);
+            tl.direction[sizeof(tl.direction) - 1] = '\0';
+
+            const char* track = leg["Origin"]["track"] | "";
+            strncpy(tl.platform, track, sizeof(tl.platform) - 1);
+            tl.platform[sizeof(tl.platform) - 1] = '\0';
+
+            conn.legCount++;
+        }
+
+        if (conn.legCount > 0) {
+            tripData.connectionCount++;
+            ESP_LOGI(TAG, "  Connection %d: %s→%s (%d min, %d legs)",
+                tripData.connectionCount,
+                conn.legs[0].departureTime,
+                conn.legs[conn.legCount - 1].arrivalTime,
+                conn.durationMinutes,
+                conn.legCount);
+        }
+    }
+
+    ESP_LOGI(TAG, "Trip: found %d connections", tripData.connectionCount);
+    return tripData.connectionCount > 0;
+}

--- a/src/api/rmv_api.cpp
+++ b/src/api/rmv_api.cpp
@@ -403,6 +403,8 @@ bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData
     filter["Trip"][0]["LegList"]["Leg"][0]["Origin"]["track"] = true;
     filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["time"] = true;
     filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["rtTime"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["Destination"]["name"] = true;
+    filter["Trip"][0]["LegList"]["Leg"][0]["cancelled"] = true;
 
     // Stream and parse
     Stream& rawStream = http.getStream();
@@ -451,9 +453,14 @@ bool getTripFromRMV(const char* originId, const char* destId, TripData& tripData
             strncpy(tl.direction, leg["direction"] | "", sizeof(tl.direction) - 1);
             tl.direction[sizeof(tl.direction) - 1] = '\0';
 
+            strncpy(tl.arrivalStation, leg["Destination"]["name"] | "", sizeof(tl.arrivalStation) - 1);
+            tl.arrivalStation[sizeof(tl.arrivalStation) - 1] = '\0';
+
             const char* track = leg["Origin"]["track"] | "";
             strncpy(tl.platform, track, sizeof(tl.platform) - 1);
             tl.platform[sizeof(tl.platform) - 1] = '\0';
+
+            tl.cancelled = leg["cancelled"] | false;
 
             conn.legCount++;
         }

--- a/src/config/config_manager.cpp
+++ b/src/config/config_manager.cpp
@@ -34,6 +34,8 @@ RTC_DATA_ATTR RTCConfigData ConfigManager::rtcConfig = {
     "", // otaCheckTime - empty = will be randomized on first boot
     FILTER_R | FILTER_S | FILTER_U | FILTER_TRAM | FILTER_BUS | FILTER_HIGHFLOOR | FILTER_FERRY | FILTER_CALLBUS,
     // filterFlags - Default filters
+    false, // tripMode - default to departures (not connections)
+    "", // tripDestId - no destination
     true, // configMode
     0, // lastUpdate
     false, // inTemporaryMode - default to normal mode
@@ -175,6 +177,10 @@ bool ConfigManager::loadFromNVS(bool force = false) {
             FILTER_FERRY | FILTER_CALLBUS;
     }
 
+    // Load trip mode configuration
+    rtcConfig.tripMode = preferences.getBool("tripMode", false);
+    String tripDest = preferences.getString("tripDestId", "");
+    copyString(rtcConfig.tripDestId, tripDest, sizeof(rtcConfig.tripDestId));
 
     preferences.end();
 
@@ -239,6 +245,9 @@ bool ConfigManager::saveToNVS() {
         preferences.putString(key.c_str(), filters[i]);
     }
 
+    // Save trip mode configuration
+    preferences.putBool("tripMode", rtcConfig.tripMode);
+    preferences.putString("tripDestId", rtcConfig.tripDestId);
 
     preferences.end();
 
@@ -497,6 +506,9 @@ void ConfigManager::updateFromJson(const JsonDocument& doc) {
     if (!doc["otaEnabled"].isNull()) config.otaEnabled = doc["otaEnabled"].as<bool>();
     if (!doc["otaCheckTime"].isNull()) strncpy(config.otaCheckTime, doc["otaCheckTime"].as<const char*>(),
                                                  sizeof(config.otaCheckTime) - 1);
+    if (!doc["tripMode"].isNull()) config.tripMode = doc["tripMode"].as<bool>();
+    if (!doc["tripDestId"].isNull()) strncpy(config.tripDestId, doc["tripDestId"].as<const char*>(),
+                                               sizeof(config.tripDestId) - 1);
 
     if (!doc["filters"].isNull()) {
         std::vector<String> filterList;

--- a/src/config/config_page.cpp
+++ b/src/config/config_page.cpp
@@ -78,6 +78,7 @@ static String renderConfigPageHtml() {
             else if (varName == "OTA_CHECK_TIME") { page += config.otaCheckTime; }
             else if (varName == "TRIP_MODE") { page += config.tripMode ? "1" : "0"; }
             else if (varName == "TRIP_DEST_ID") { page += config.tripDestId; }
+            else if (varName == "STOP_ID") { page += config.selectedStopId; }
             else if (varName == "SAVED_FILTERS") { page += filtersJs; }
             else if (varName == "LAT") { page += String(pageData.getLatitude(), 6); }
             else if (varName == "LON") { page += String(pageData.getLongitude(), 6); }

--- a/src/config/config_page.cpp
+++ b/src/config/config_page.cpp
@@ -76,6 +76,8 @@ static String renderConfigPageHtml() {
             else if (varName == "WEEKEND_SLEEP_END") { page += config.weekendSleepEnd; }
             else if (varName == "OTA_ENABLED") { page += config.otaEnabled ? "true" : "false"; }
             else if (varName == "OTA_CHECK_TIME") { page += config.otaCheckTime; }
+            else if (varName == "TRIP_MODE") { page += config.tripMode ? "1" : "0"; }
+            else if (varName == "TRIP_DEST_ID") { page += config.tripDestId; }
             else if (varName == "SAVED_FILTERS") { page += filtersJs; }
             else if (varName == "LAT") { page += String(pageData.getLatitude(), 6); }
             else if (varName == "LON") { page += String(pageData.getLongitude(), 6); }

--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -7,6 +7,7 @@
 #include "display/weather_general_half.h"
 #include "display/weather_general_full.h"
 #include "display/common_footer.h"
+#include "display/trip_display.h"
 #include "display/qr_code_helper.h"
 #include "util/util.h"
 
@@ -56,6 +57,19 @@ void DisplayManager::displayHalfNHalf(const WeatherInfo& weather,
 
         // Draw vertical divider
         displayVerticalLine(contentY);
+    } while (display.nextPage());
+}
+
+void DisplayManager::displayHalfNHalfTrip(const WeatherInfo& weather, const TripData& tripData) {
+    ESP_LOGI(TAG, "Full update - weather + trip connections");
+
+    display.setFullWindow();
+    display.firstPage();
+    do {
+        display.fillScreen(GxEPD_WHITE);
+        updateWeatherHalf(weather);
+        TripDisplay::drawTripConnections(tripData, halfWidth + 1, 0, screenWidth - halfWidth - 1, screenHeight);
+        displayVerticalLine(0);
     } while (display.nextPage());
 }
 

--- a/src/display/trip_display.cpp
+++ b/src/display/trip_display.cpp
@@ -1,0 +1,198 @@
+#include "display/trip_display.h"
+#include "display/text_utils.h"
+#include "config/config_manager.h"
+#include "util/util.h"
+#include "global_instances.h"
+#include <esp_log.h>
+#include <time.h>
+
+static const char* TAG = "TRIP_DISPLAY";
+
+static constexpr int16_t ROW_HEIGHT = 18;
+static constexpr int16_t CONNECTION_HEIGHT = 75; // 480px - 28px header = 452px / 6 connections
+static constexpr int16_t HEADER_HEIGHT = 30;
+static constexpr int16_t MARGIN = 5;
+static constexpr int16_t COL_LINES = 70;
+
+String TripDisplay::extractStopName(const char* stopId) {
+    String id = String(stopId);
+    int oStart = id.indexOf("@O=");
+    if (oStart < 0) return id;
+    oStart += 3;
+    int oEnd = id.indexOf('@', oStart);
+    if (oEnd < 0) return id.substring(oStart);
+    return id.substring(oStart, oEnd);
+}
+
+int16_t TripDisplay::getConnectionHeight(const TripConnection& conn) {
+    return CONNECTION_HEIGHT; // Fixed 3-row height
+}
+
+void TripDisplay::drawTripConnections(const TripData& tripData, int16_t x, int16_t y, int16_t w, int16_t h) {
+    ESP_LOGI(TAG, "Drawing %d trip connections at (%d,%d) %dx%d", tripData.connectionCount, x, y, w, h);
+
+    RTCConfigData& config = ConfigManager::getConfig();
+
+    // Header: Origin → Destination (strip city name)
+    TextUtils::setFont12px_margin15px();
+    String originFull = extractStopName(config.selectedStopId);
+    String destFull = extractStopName(config.tripDestId);
+    // Use the full destination as reference to strip city from origin, and vice versa
+    String origin = Util::shortenDestination(destFull, originFull);
+    String dest = Util::shortenDestination(originFull, destFull);
+    if (origin.isEmpty()) origin = Util::shortenStationName(originFull);
+    if (dest.isEmpty()) dest = Util::shortenStationName(destFull);
+    String header = origin + " -> " + dest;
+    header = TextUtils::shortenTextToFit(header, w - MARGIN * 2);
+    TextUtils::printTextAtTopMargin(x + MARGIN, y, header);
+    y += 24; // More spacing after header
+
+    // Separator line
+    display.drawFastHLine(x, y, w, GxEPD_BLACK);
+    y += 4;
+
+    // Current time for "in X min"
+    time_t now;
+    time(&now);
+    uint32_t currentTime = (uint32_t)now;
+
+    // Draw connections
+    TextUtils::setFont10px_margin12px();
+    for (int i = 0; i < tripData.connectionCount; i++) {
+        if (y + CONNECTION_HEIGHT > h) break;
+
+        drawSingleConnection(tripData.connections[i], x, y, w, CONNECTION_HEIGHT, currentTime);
+        y += CONNECTION_HEIGHT;
+
+        // Separator
+        display.drawFastHLine(x + MARGIN, y - 4, w - MARGIN * 2, GxEPD_BLACK);
+    }
+
+    if (tripData.connectionCount == 0) {
+        TextUtils::printTextAtTopMargin(x + MARGIN, y + 10, "Keine Verbindungen gefunden");
+    }
+}
+
+int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x, int16_t y,
+                                           int16_t w, int16_t maxH, uint32_t currentTime) {
+    int16_t rightEdge = x + w - MARGIN;
+    int16_t leftX = x + MARGIN;
+    RTCConfigData& config = ConfigManager::getConfig();
+    String originFull = extractStopName(config.selectedStopId);
+
+    // === ROW 1: dep_time [+delay]  [line1] -O- [line2]  arr_time [+delay]  duration ===
+    int16_t row1Y = y + 10;
+
+    // Departure time
+    TextUtils::printTextAtTopMargin(leftX, row1Y, conn.legs[0].departureTime);
+
+    // Departure delay
+    int16_t currentX = leftX + 35;
+    if (conn.legs[0].rtDepartureTime[0] != '\0' &&
+        strcmp(conn.legs[0].rtDepartureTime, conn.legs[0].departureTime) != 0) {
+        int schedMin = atoi(conn.legs[0].departureTime) * 60 + atoi(conn.legs[0].departureTime + 3);
+        int rtMin = atoi(conn.legs[0].rtDepartureTime) * 60 + atoi(conn.legs[0].rtDepartureTime + 3);
+        int delay = rtMin - schedMin;
+        if (delay > 0) {
+            String delayStr = "+" + String(delay);
+            TextUtils::printTextAtTopMargin(currentX, row1Y, delayStr.c_str());
+        }
+    }
+
+    // Line boxes with -O- transfer symbols
+    currentX = leftX + COL_LINES;
+    for (int leg = 0; leg < conn.legCount; leg++) {
+        if (leg > 0) {
+            TextUtils::printTextAtTopMargin(currentX, row1Y, "-O-");
+            currentX += TextUtils::getTextWidth("-O-") + 2;
+        }
+        String line = String(conn.legs[leg].line);
+        int16_t lineW = TextUtils::getTextWidth(line) + 6;
+        // Don't overflow into arrival area
+        if (currentX + lineW > rightEdge - 90) break;
+        display.drawRect(currentX, row1Y - 1, lineW, ROW_HEIGHT - 4, GxEPD_BLACK);
+        TextUtils::printTextAtTopMargin(currentX + 3, row1Y, line.c_str());
+        currentX += lineW + 4;
+    }
+
+    // Duration (far right)
+    String durStr = String(conn.durationMinutes) + " min";
+    int16_t durW = TextUtils::getTextWidth(durStr);
+    TextUtils::printTextAtTopMargin(rightEdge - durW, row1Y, durStr.c_str());
+
+    // Arrival time
+    const TripLeg& lastLeg = conn.legs[conn.legCount - 1];
+    String arrStr = String(lastLeg.arrivalTime);
+    int16_t arrW = TextUtils::getTextWidth(arrStr);
+    int16_t arrX = rightEdge - durW - arrW - 10;
+    TextUtils::printTextAtTopMargin(arrX, row1Y, arrStr.c_str());
+
+    // Arrival delay
+    if (lastLeg.rtArrivalTime[0] != '\0' &&
+        strcmp(lastLeg.rtArrivalTime, lastLeg.arrivalTime) != 0) {
+        int schedMin = atoi(lastLeg.arrivalTime) * 60 + atoi(lastLeg.arrivalTime + 3);
+        int rtMin = atoi(lastLeg.rtArrivalTime) * 60 + atoi(lastLeg.rtArrivalTime + 3);
+        int delay = rtMin - schedMin;
+        if (delay > 0) {
+            String delayStr = "+" + String(delay);
+            TextUtils::printTextAtTopMargin(arrX + arrW + 2, row1Y, delayStr.c_str());
+        }
+    }
+
+    // === ROW 2: "in X min" + Transfer 1 ===
+    int16_t row2Y = row1Y + ROW_HEIGHT;
+
+    // "in X min"
+    int depHour = atoi(conn.legs[0].departureTime);
+    int depMin = atoi(conn.legs[0].departureTime + 3);
+    if (conn.legs[0].rtDepartureTime[0] != '\0') {
+        depHour = atoi(conn.legs[0].rtDepartureTime);
+        depMin = atoi(conn.legs[0].rtDepartureTime + 3);
+    }
+    struct tm* nowTm = localtime((time_t*)&currentTime);
+    int nowMinutes = nowTm->tm_hour * 60 + nowTm->tm_min;
+    int depMinutes = depHour * 60 + depMin;
+    int minutesUntil = depMinutes - nowMinutes;
+    if (minutesUntil < 0) minutesUntil += 24 * 60;
+
+    String inStr = "in " + String(minutesUntil) + " min";
+    TextUtils::printTextAtTopMargin(leftX, row2Y, inStr.c_str());
+
+    // Transfer 1 (if exists)
+    if (conn.legCount > 1) {
+        int arrMin = atoi(conn.legs[0].arrivalTime) * 60 + atoi(conn.legs[0].arrivalTime + 3);
+        int nextDepMin = atoi(conn.legs[1].departureTime) * 60 + atoi(conn.legs[1].departureTime + 3);
+        int transferTime = nextDepMin - arrMin;
+        if (transferTime < 0) transferTime += 24 * 60;
+
+        String station = Util::shortenDestination(originFull, String(conn.legs[0].direction));
+        String transferStr = "Umst: " + station + " (" + String(transferTime) + " min)";
+        int16_t maxTransferW = w - COL_LINES - MARGIN;
+        transferStr = TextUtils::shortenTextToFit(transferStr, maxTransferW);
+        TextUtils::printTextAtTopMargin(leftX + COL_LINES, row2Y, transferStr.c_str());
+    }
+
+    // === ROW 3: Transfer 2+ (combined on one line if multiple) ===
+    int16_t row3Y = row2Y + ROW_HEIGHT;
+
+    if (conn.legCount > 2) {
+        String combined = "";
+        for (int leg = 1; leg < conn.legCount - 1; leg++) {
+            int arrMin = atoi(conn.legs[leg].arrivalTime) * 60 + atoi(conn.legs[leg].arrivalTime + 3);
+            int nextDepMin = atoi(conn.legs[leg + 1].departureTime) * 60 +
+                             atoi(conn.legs[leg + 1].departureTime + 3);
+            int transferTime = nextDepMin - arrMin;
+            if (transferTime < 0) transferTime += 24 * 60;
+
+            String station = Util::shortenDestination(originFull, String(conn.legs[leg].direction));
+            if (combined.length() > 0) combined += ", ";
+            combined += station + " (" + String(transferTime) + " min)";
+        }
+        String transferStr = "Umst: " + combined;
+        int16_t maxTransferW = w - COL_LINES - MARGIN;
+        transferStr = TextUtils::shortenTextToFit(transferStr, maxTransferW);
+        TextUtils::printTextAtTopMargin(leftX + COL_LINES, row3Y, transferStr.c_str());
+    }
+
+    return CONNECTION_HEIGHT;
+}

--- a/src/display/trip_display.cpp
+++ b/src/display/trip_display.cpp
@@ -83,11 +83,27 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
     // === ROW 1: dep_time [+delay]  [line1] -O- [line2]  arr_time [+delay]  duration ===
     int16_t row1Y = y + 10;
 
-    // Departure time
-    TextUtils::printTextAtTopMargin(leftX, row1Y, conn.legs[0].departureTime);
+    // Fixed column positions for vertical alignment across all connections
+    int16_t colDepTime = leftX;
+    int16_t colDelay = leftX + 38;  // gap after "23:06"
+    int16_t colLines = leftX + COL_LINES;
+    int16_t colArrTime = rightEdge - TextUtils::getTextWidth("23:06") - 5;
+    int16_t colArrDelay = colArrTime + TextUtils::getTextWidth("23:06") + 3;
 
-    // Departure delay
-    int16_t currentX = leftX + 35;
+    // Check if any leg is cancelled
+    bool hasCancelled = false;
+    for (int leg = 0; leg < conn.legCount; leg++) {
+        if (conn.legs[leg].cancelled) { hasCancelled = true; break; }
+    }
+
+    // Departure time (strikethrough if cancelled)
+    if (hasCancelled) {
+        TextUtils::printStrikethroughTextAtTopMargin(colDepTime, row1Y, conn.legs[0].departureTime);
+    } else {
+        TextUtils::printTextAtTopMargin(colDepTime, row1Y, conn.legs[0].departureTime);
+    }
+
+    // Departure delay (more space from time)
     if (conn.legs[0].rtDepartureTime[0] != '\0' &&
         strcmp(conn.legs[0].rtDepartureTime, conn.legs[0].departureTime) != 0) {
         int schedMin = atoi(conn.legs[0].departureTime) * 60 + atoi(conn.legs[0].departureTime + 3);
@@ -95,12 +111,12 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
         int delay = rtMin - schedMin;
         if (delay > 0) {
             String delayStr = "+" + String(delay);
-            TextUtils::printTextAtTopMargin(currentX, row1Y, delayStr.c_str());
+            TextUtils::printTextAtTopMargin(colDelay, row1Y, delayStr.c_str());
         }
     }
 
     // Line boxes with -O- transfer symbols
-    currentX = leftX + COL_LINES;
+    int16_t currentX = colLines;
     for (int leg = 0; leg < conn.legCount; leg++) {
         if (leg > 0) {
             TextUtils::printTextAtTopMargin(currentX, row1Y, "-O-");
@@ -108,24 +124,20 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
         }
         String line = String(conn.legs[leg].line);
         int16_t lineW = TextUtils::getTextWidth(line) + 6;
-        // Don't overflow into arrival area
-        if (currentX + lineW > rightEdge - 90) break;
+        // Don't overflow into arrival time area
+        if (currentX + lineW > colArrTime - 5) break;
         display.drawRect(currentX, row1Y - 1, lineW, ROW_HEIGHT - 4, GxEPD_BLACK);
         TextUtils::printTextAtTopMargin(currentX + 3, row1Y, line.c_str());
         currentX += lineW + 4;
     }
 
-    // Duration (far right)
-    String durStr = String(conn.durationMinutes) + " min";
-    int16_t durW = TextUtils::getTextWidth(durStr);
-    TextUtils::printTextAtTopMargin(rightEdge - durW, row1Y, durStr.c_str());
-
-    // Arrival time
+    // Arrival time (fixed position, right side of row 1)
     const TripLeg& lastLeg = conn.legs[conn.legCount - 1];
-    String arrStr = String(lastLeg.arrivalTime);
-    int16_t arrW = TextUtils::getTextWidth(arrStr);
-    int16_t arrX = rightEdge - durW - arrW - 10;
-    TextUtils::printTextAtTopMargin(arrX, row1Y, arrStr.c_str());
+    if (hasCancelled) {
+        TextUtils::printStrikethroughTextAtTopMargin(colArrTime, row1Y, lastLeg.arrivalTime);
+    } else {
+        TextUtils::printTextAtTopMargin(colArrTime, row1Y, lastLeg.arrivalTime);
+    }
 
     // Arrival delay
     if (lastLeg.rtArrivalTime[0] != '\0' &&
@@ -135,28 +147,38 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
         int delay = rtMin - schedMin;
         if (delay > 0) {
             String delayStr = "+" + String(delay);
-            TextUtils::printTextAtTopMargin(arrX + arrW + 2, row1Y, delayStr.c_str());
+            TextUtils::printTextAtTopMargin(colArrDelay, row1Y, delayStr.c_str());
         }
     }
 
     // === ROW 2: "in X min" + Transfer 1 ===
     int16_t row2Y = row1Y + ROW_HEIGHT;
 
-    // "in X min"
-    int depHour = atoi(conn.legs[0].departureTime);
-    int depMin = atoi(conn.legs[0].departureTime + 3);
-    if (conn.legs[0].rtDepartureTime[0] != '\0') {
-        depHour = atoi(conn.legs[0].rtDepartureTime);
-        depMin = atoi(conn.legs[0].rtDepartureTime + 3);
+    String inStr;
+    if (hasCancelled) {
+        inStr = "Fällt aus";
+    } else {
+        int depHour = atoi(conn.legs[0].departureTime);
+        int depMin = atoi(conn.legs[0].departureTime + 3);
+        if (conn.legs[0].rtDepartureTime[0] != '\0') {
+            depHour = atoi(conn.legs[0].rtDepartureTime);
+            depMin = atoi(conn.legs[0].rtDepartureTime + 3);
+        }
+        struct tm* nowTm = localtime((time_t*)&currentTime);
+        int nowMinutes = nowTm->tm_hour * 60 + nowTm->tm_min;
+        int depMinutes = depHour * 60 + depMin;
+        int minutesUntil = depMinutes - nowMinutes;
+        if (minutesUntil < 0) minutesUntil += 24 * 60;
+        inStr = "in " + String(minutesUntil) + " min";
     }
-    struct tm* nowTm = localtime((time_t*)&currentTime);
-    int nowMinutes = nowTm->tm_hour * 60 + nowTm->tm_min;
-    int depMinutes = depHour * 60 + depMin;
-    int minutesUntil = depMinutes - nowMinutes;
-    if (minutesUntil < 0) minutesUntil += 24 * 60;
-
-    String inStr = "in " + String(minutesUntil) + " min";
+    inStr = TextUtils::shortenTextToFit(inStr, COL_LINES - 5);
     TextUtils::printTextAtTopMargin(leftX, row2Y, inStr.c_str());
+    int16_t transferColX = leftX + COL_LINES; // Align with line boxes above
+
+    // Duration (right-aligned on row 2, always shown)
+    String durStr = String(conn.durationMinutes) + " min";
+    int16_t durW = TextUtils::getTextWidth(durStr);
+    TextUtils::printTextAtTopMargin(rightEdge - durW, row2Y, durStr.c_str());
 
     // Transfer 1 (if exists)
     if (conn.legCount > 1) {
@@ -165,11 +187,11 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
         int transferTime = nextDepMin - arrMin;
         if (transferTime < 0) transferTime += 24 * 60;
 
-        String station = Util::shortenDestination(originFull, String(conn.legs[0].direction));
+        String station = Util::shortenDestination(originFull, String(conn.legs[0].arrivalStation));
         String transferStr = "Umst: " + station + " (" + String(transferTime) + " min)";
-        int16_t maxTransferW = w - COL_LINES - MARGIN;
+        int16_t maxTransferW = (x + w) - transferColX - MARGIN;
         transferStr = TextUtils::shortenTextToFit(transferStr, maxTransferW);
-        TextUtils::printTextAtTopMargin(leftX + COL_LINES, row2Y, transferStr.c_str());
+        TextUtils::printTextAtTopMargin(transferColX, row2Y, transferStr.c_str());
     }
 
     // === ROW 3: Transfer 2+ (combined on one line if multiple) ===
@@ -184,14 +206,14 @@ int16_t TripDisplay::drawSingleConnection(const TripConnection& conn, int16_t x,
             int transferTime = nextDepMin - arrMin;
             if (transferTime < 0) transferTime += 24 * 60;
 
-            String station = Util::shortenDestination(originFull, String(conn.legs[leg].direction));
+            String station = Util::shortenDestination(originFull, String(conn.legs[leg].arrivalStation));
             if (combined.length() > 0) combined += ", ";
             combined += station + " (" + String(transferTime) + " min)";
         }
         String transferStr = "Umst: " + combined;
-        int16_t maxTransferW = w - COL_LINES - MARGIN;
+        int16_t maxTransferW = (x + w) - transferColX - MARGIN;
         transferStr = TextUtils::shortenTextToFit(transferStr, maxTransferW);
-        TextUtils::printTextAtTopMargin(leftX + COL_LINES, row3Y, transferStr.c_str());
+        TextUtils::printTextAtTopMargin(transferColX, row3Y, transferStr.c_str());
     }
 
     return CONNECTION_HEIGHT;

--- a/src/util/device_mode_manager.cpp
+++ b/src/util/device_mode_manager.cpp
@@ -104,7 +104,8 @@ void DeviceModeManager::showWeatherDeparture() {
 
     if (config.tripMode) {
         // Trip/connection mode
-        TripData trip;
+        static TripData trip; // static: ~4KB too large for stack
+        memset(&trip, 0, sizeof(trip));
         getTripFromRMV(config.selectedStopId, config.tripDestId, trip);
         TimingManager::markTransportUpdated();
         shutdownWiFiBeforeRender();

--- a/src/util/device_mode_manager.cpp
+++ b/src/util/device_mode_manager.cpp
@@ -12,6 +12,7 @@
 #include "config/config_page_data.h"
 #include "config/config_struct.h"
 #include "display/display_manager.h"
+#include "display/trip_display.h"
 #include "util/battery_manager.h"
 #include "util/transport_print.h"
 #include "global_instances.h"
@@ -96,20 +97,26 @@ void DeviceModeManager::showWeatherDeparture() {
     bool needsWeatherUpdate = TimingManager::isTimeForWeatherUpdate();
     ESP_LOGI(TAG, "Update requirements - Weather: %s", needsWeatherUpdate ? "YES" : "NO");
 
-    DepartureData depart;
-
-    // Path: Update both weather and departure - FULL REFRESH
-    ESP_LOGI(TAG, "Updating both weather and departure data");
-
     if (needsWeatherUpdate && getGeneralWeatherFull(config.latitude, config.longitude, weather)) {
         printWeatherInfo(weather);
         TimingManager::markWeatherUpdated();
     }
-    fetchTransportData(depart);
-    TimingManager::markTransportUpdated();
 
-    shutdownWiFiBeforeRender();
-    DisplayManager::displayHalfNHalf(weather, depart);
+    if (config.tripMode) {
+        // Trip/connection mode
+        TripData trip;
+        getTripFromRMV(config.selectedStopId, config.tripDestId, trip);
+        TimingManager::markTransportUpdated();
+        shutdownWiFiBeforeRender();
+        DisplayManager::displayHalfNHalfTrip(weather, trip);
+    } else {
+        // Departure mode
+        DepartureData depart;
+        fetchTransportData(depart);
+        TimingManager::markTransportUpdated();
+        shutdownWiFiBeforeRender();
+        DisplayManager::displayHalfNHalf(weather, depart);
+    }
 }
 
 void DeviceModeManager::updateWeatherFull() {

--- a/test/test_timing_manager/mocks/config_manager.cpp
+++ b/test/test_timing_manager/mocks/config_manager.cpp
@@ -32,10 +32,12 @@ RTCConfigData ConfigManager::rtcConfig = {
     (uint16_t)(
         FILTER_R | FILTER_S | FILTER_U | FILTER_TRAM | FILTER_BUS | FILTER_HIGHFLOOR | FILTER_FERRY | FILTER_CALLBUS),
     // filterFlags
+    false, // tripMode
+    "", // tripDestId
     false, // configMode
     0, // lastUpdate
     false, // inTemporaryMode
-    0xFF, // temporaryDisplayMode
+    (uint8_t)0xFF, // temporaryDisplayMode
     0 // temporaryModeActivationTime
 };
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -77,6 +77,11 @@ const config = {
         ({
             // Replace with your project's social card
             image: 'img/docusaurus-social-card.jpg',
+            docs: {
+                sidebar: {
+                    autoCollapseCategories: false,
+                },
+            },
             navbar: {
                 title: 'MyStation',
                 items: [

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -18,6 +18,7 @@ const sidebars = {
         {
             type: 'category',
             label: '🏗️ Architecture',
+            collapsed: false,
             items: [
                 'developer-guide/index',
                 'developer-guide/boot-process',
@@ -27,6 +28,7 @@ const sidebars = {
         {
             type: 'category',
             label: '⚙️ Core Systems',
+            collapsed: false,
             items: [
                 'developer-guide/display-system',
                 'developer-guide/button-system',
@@ -36,6 +38,7 @@ const sidebars = {
         {
             type: 'category',
             label: '📡 APIs & Integration',
+            collapsed: false,
             items: [
                 'developer-guide/api-integration',
             ],
@@ -43,6 +46,7 @@ const sidebars = {
         {
             type: 'category',
             label: '🛠️ Development',
+            collapsed: false,
             items: [
                 'developer-guide/development-setup',
                 'developer-guide/testing',
@@ -54,6 +58,7 @@ const sidebars = {
         {
             type: 'category',
             label: '🔌 Hardware',
+            collapsed: false,
             items: [
                 'developer-guide/hardware-assembly',
                 'hardware-setup',
@@ -61,11 +66,12 @@ const sidebars = {
         },
     ],
 
-    // Quick Reference Sidebar - For quick lookups
+    // Maintainer Guide Sidebar
     maintainerSidebar: [
         {
             type: 'category',
             label: '📋 Maintainer Guide',
+            collapsed: false,
             items: [
                 'maintainer-guide/release-process',
                 'maintainer-guide/ota-update',
@@ -75,11 +81,12 @@ const sidebars = {
         },
     ],
 
-    // Quick Reference Sidebar - For quick lookups
+    // Quick Reference Sidebar
     referenceSidebar: [
         {
             type: 'category',
             label: '📋 Quick Reference',
+            collapsed: false,
             items: [
                 'reference/configuration-keys-quick-reference',
             ],
@@ -88,4 +95,3 @@ const sidebars = {
 };
 
 export default sidebars;
-


### PR DESCRIPTION
## Epic: Trip/Connection Information

Shows how to get from A to B instead of just departure times from a single stop.

### Features

- **Configuration** (#283): Toggle between Abfahrten/Verbindungen, destination stop autocomplete
- **API** (#305): Fetch connections from RMV /hapi/trip with streaming JSON filter, walking time offset, product filter
- **Display** (#304): Render connections with line boxes, -O- transfer symbols, delay info, cancellation

### Display Layout

```
Row 1: 07:12  +3   [S3] -O- [RE60]              07:38  +5
Row 2: in 5 min    Umst: Hauptwache (5 min)      26 min
Row 3:             Umst: Langen (3 min)
```

### Bug Fixes (included)

- Stack overflow fix (TripData too large for stack → static)
- Transfer station shows actual stop name (not vehicle direction)
- Cancelled legs with strikethrough + 'Fällt aus'
- Column alignment, spacing, city qualifier stripping
- Config pre-selection after app reset

### Documentation

- Configuration keys reference updated
- Boot process ON_RUNNING documents trip routing
- Sidebar categories expanded by default

### Tests

- Build: SUCCESS
- Native: 42/42 pass